### PR TITLE
docs: edit install instructions

### DIFF
--- a/rsk/node/install/centos.md
+++ b/rsk/node/install/centos.md
@@ -2,11 +2,12 @@
 layout: rsk
 title: Setup node on CentOS
 ---
+
+Make sure your system meets the [minimum requirements](../requirements/) before installing RSK nodes on it.
+
 ## Install RSK node in CentOS Distribution
 
-
-Using the scripts below to install and run a RSK node on CentOS. By default, the node connects to MainNet.  To change the network choice, follow the instructions on [Switching Networks](https://github.com/rsksmart/rskj/wiki/Switching-networks). To change other configuration of the node, please refer to the instructions on [RSK Node Configuration](https://github.com/rsksmart/rskj/wiki/RSK-node-configuration).
-
+Use the script below to install and run an RSK node on CentOS.
 
 ```shell
 #!/bin/bash
@@ -67,3 +68,5 @@ sudo systemctl enable rsk.service
 sudo service rsk start
 
 ```
+
+By default, the node connects to MainNet.  To change the network choice, follow the instructions on [Switching Networks](https://github.com/rsksmart/rskj/wiki/Switching-networks). To change other configuration of the node, please refer to the instructions on [RSK Node Configuration](https://github.com/rsksmart/rskj/wiki/RSK-node-configuration).

--- a/rsk/node/install/docker.md
+++ b/rsk/node/install/docker.md
@@ -3,47 +3,53 @@ layout: rsk
 title: Setup node on Docker
 ---
 
+Make sure your system meets the [minimum requirements](../requirements/) before installing RSK nodes on it.
+
+For this method, you also need to install [Docker](https://docs.docker.com/install/).
+
 ## Install RskJ Using Docker
+
 First of all, download the RSK a Dockerfile and supervisord.conf from [artifacts repo](https://github.com/rsksmart/artifacts/tree/master/Dockerfiles/RSK-Node).
 
 Inside the artifacts repo, you can choose which ***type of*** node you are going to install:
-* A node connected to RSK MainNet: Dockerfile.MainNet
-* A node connected to RSK TestNet: Dockerfile.TestNet
-* A node Standalone/RegTest or private network: Dockerfile.RegTest
+
+* A node connected to the public RSK MainNet: `Dockerfile.MainNet`
+* A node connected to the public RSK TestNet: `Dockerfile.TestNet`
+* A node connected to a private RegTest network: `Dockerfile.RegTest`
 
 #### Install the node using Docker containers
-This only can be done in a machine that is already [running Docker](https://docs.docker.com/install/).
 
 Then build the container by running (depending on your node's type):
-* MaiNet
-``` 
-docker build -t mainnet -f Dockerfile.MainNet .
-```
+
+* MainNet
+  ```
+  docker build -t mainnet -f Dockerfile.MainNet .
+  ```
 * TestNet
-```
-docker build -t testnet -f Dockerfile.TestNet .
-```
+  ```
+  docker build -t testnet -f Dockerfile.TestNet .
+  ```
 * RegTest
-```
-docker build -t regtest -f Dockerfile.RegTest .
-```
+  ```
+  docker build -t regtest -f Dockerfile.RegTest .
+  ```
 
 When the build finishes, you have a container ready to run RSK.
 
 To run the container, you should execute (depending on your node's type):
 
-* MaiNet
-```
-docker run -d --name mainnet-node-01  -p 4444:4444 -p 5050:5050 mainnet
-```
+* MainNet
+  ```
+  docker run -d --name mainnet-node-01  -p 4444:4444 -p 5050:5050 mainnet
+  ```
 * TestNet
-```
-docker run -d --name testnet-node-01  -p 4444:4444 -p 50505:50505 testnet
-```
+  ```
+  docker run -d --name testnet-node-01  -p 4444:4444 -p 50505:50505 testnet
+  ```
 * RegTest
-```
-docker run -d --name regtest-node-01  -p 4444:4444 -p 30305:30305 regtest
-```
+  ```
+  docker run -d --name regtest-node-01  -p 4444:4444 -p 30305:30305 regtest
+  ```
 
 ## Video
 

--- a/rsk/node/install/index.md
+++ b/rsk/node/install/index.md
@@ -8,12 +8,12 @@ title: Install
     height:25px;
   }
 </style>
-### Install RSK Node and Join the RSK Orchid Mainnet Beta
 
-> Minimum Requirement
-Make sure your system meet the [Minimum Requirement](https://github.com/rsksmart/rskj/wiki/Node-Minimum-Requirements) before installing the RSK nodes on it.  
+Ensure that your system meets the [minimum requirements](./requirements/) before installing the RSK nodes on it.
 
-RSK node can be installed on all major platforms, including Linux, Windows, and Mac. Here we provide step-by-step instructions for all supported platforms. Depending on your network performance, it usually takes 10 to 15 mins to setup a working node on mainnet.
+### Install RSK Node and Join the RSK Orchid MainNet Beta
+
+RSK nodes can be installed on all major platforms, including Linux, Windows, and Mac. Here we provide step-by-step instructions for all supported platforms. Depending on your network performance, it usually takes 10 to 15 mins to setup a working node on MainNet.
 
 #### Supported Systems and Methods
 
@@ -83,30 +83,31 @@ RSK node can be installed on all major platforms, including Linux, Windows, and 
 </table>
 
 #### Using Ubuntu Package
+
 <img class="node-setup-img" src="https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png" alt="ubuntu logo"/>
 
 Visit [Setup Node on Ubuntu](./ubuntu) for instructions on installing RSK Node on ubuntu systems
 
-
 #### Using Fat(or Uber) JAR
+
 <img class="node-setup-img" src="https://www.pngkey.com/png/detail/264-2646582_logo-transparent-background-java.png" alt="java logo"/>
 
 Visit [Setup Node through JAR](./java) for instructions on installing RSK Node on any system with Fat JAR or Uber JAR.
 
-
 #### Using Docker Container
+
 <img class="node-setup-img" height="25px" src="https://goto.docker.com/rs/929-FJL-178/images/Docker%20Horizontal%20Large.png" alt="docker logo"/>
 
 Visit [Setup Node through Docker](./docker) for instructions on installing RSK Node as a docker container on any system.
 
-
 #### Using AWS AMI
+
 <img class="node-setup-img" height="25px" src="https://kopano.com/wp-content/uploads/2018/04/AWSCloud.png" alt="aws logo"/>
 
 Visit [Setup Node through AWS AMI](./aws) for instructions on installing RSK Node on a AWS instance through marketplace AMI.
 
-
 #### Using Azure
+
 <img class="node-setup-img" height="25px" src="https://scaidata.com/assets/img/scaidata_business_intelligence_azure_marketplace_azure_cloud1.png.png" alt="azure logo"/>
 
 Visit [Setup Node through Azure](./azure) for instructions on installing RSK Node on a Azure instance through marketplace image resource.

--- a/rsk/node/install/java.md
+++ b/rsk/node/install/java.md
@@ -3,33 +3,35 @@ layout: rsk
 title: Setup node on Java
 ---
 
-## Install the node using RskJ Fat (or Uber) JAR
+Make sure your system meets the [minimum requirements](../requirements/) before installing RSK nodes on it.
+
+You also need to install [Java 8 JDK](https://www.java.com/download/).
+
+## Install the node using a JAR file
 
 The Fat JAR or Uber JAR can be [downloaded](https://github.com/rsksmart/rskj/releases) or compiled (in a [reproducible way](https://github.com/rsksmart/rskj/wiki/Reproducible-Build) or [not](https://github.com/rsksmart/rskj/wiki/Compile-and-run-a-RSK-node-locally)).
 
-Once you have the JAR, you should install [Java 8 JDK](https://www.java.com/es/download/).
-
 To run the node:
 ```bash
-$ java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start 
+$ java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
 ```
 
-Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-1.0.2-WASABI-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-1.1.0-WASABI-all.jar`
 
-## Check everything's working with an RPC call
+## Check the RPC
 
-If you see no output, then it means the node is running. To check, you can open a new console tab (it's important you don't close this one or interrupt the process) and issue a request to the node's RPC HTTP server. This is an example using cURL:
+If you see no output, it means that the node is running. To check, you can open a new console tab (it is important you do not close this one or interrupt the process) and issue a request to the node's RPC HTTP server. This is an example using cURL:
 
 ```bash
-$ curl localhost:4444 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+$ curl localhost:4444/1.1.0/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```
 
-The response should be something like `{"jsonrpc":"2.0","id":1,"result":"0xfc0"}`, where the `result` property is the number of the latest block you've synced so far (in hexadecimal).
-
-
+The response should look similar to `{"jsonrpc":"2.0","id":1,"result":"0xfc0"}`, where the `result` property is the number of the latest block that has been synced (in hexadecimal).
 
 ## Switching networks
+
 If you want to change the network use these commands:
+
 - MainNet: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start`
 - TestNet: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --testnet`
 - RegTest: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --regtest`

--- a/rsk/node/install/requirements.md
+++ b/rsk/node/install/requirements.md
@@ -3,7 +3,7 @@ layout: rsk
 title: Hardware requirements
 ---
 
-These are the minimum requirements that should be taken into account to run an RSK node:
+These are the minimum requirements that must be met to run an RSK node:
 
 - 2 cores
 - 8 GB RAM

--- a/rsk/node/install/ubuntu.md
+++ b/rsk/node/install/ubuntu.md
@@ -3,19 +3,15 @@ layout: rsk
 title: Setup node on Ubuntu
 ---
 
+Make sure your system meets the [minimum requirements](../requirements/) before installing RSK nodes on it.
 
-> Minimum Requirement
-Make sure your system meet the [Minimum Requirement](https://github.com/rsksmart/rskj/wiki/Node-Minimum-Requirements) before installing the RSK nodes on it.  
+## Install via Ubuntu Package Manager
 
-## Install RSK node via Ubuntu Package
-
-The easiest way to install and run a RSK node on Ubuntu is to do it through Ubuntu Package. By default, the node connects to MainNet.  To change the network choice, follow the instructions on [Switching Networks](https://github.com/rsksmart/rskj/wiki/Switching-networks). To change other configuration of the node, please refer to the instructions on [RSK Node Configuration](https://github.com/rsksmart/rskj/wiki/RSK-node-configuration).
-
-### Install via PPA
+The easiest way to install and run a RSK node on Ubuntu is to do it through Ubuntu Package Manager.
 
 Type the commands below to install RskJ on Ubuntu using our PPAs for Ubuntu. 
 
-The installed repo public key Fingerprint is 5EED 9995 C84A 49BC 02D4 F507 DF10 691F 518C 7BEA. Also, the public key could be found in document [Ubuntu Key Server](https://keyserver.ubuntu.com/).
+The installed repo public key Fingerprint is `5EED 9995 C84A 49BC 02D4 F507 DF10 691F 518C 7BEA`. Also, the public key could be found in document [Ubuntu Key Server](https://keyserver.ubuntu.com/).
 
 ```shell
 $ sudo add-apt-repository ppa:rsksmart/rskj
@@ -31,13 +27,11 @@ Choose Yes and Enter to accept the license to continue
 
 <img alt="choose mainnet" class="setup-node-ubuntu" src="https://files.readme.io/53d7723-Screen_Shot_2019-06-04_at_1.11.54_PM.png">
 
-Choose Mainnet and Enter to continue
+Choose `mainnet` and press `Enter` to continue
 
+## Install via Direct Downloads
 
-
-### Install via Direct Downloads
-
-You can also download the RskJ Ubuntu Package for Orchid 0.6.2 and install it with command dpkg. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matched package for your ubuntu system.
+You can also download the RskJ Ubuntu Package for Orchid 0.6.2 and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
 
 ```shell
 # first install openjdk-8-jre or oracle-java8-installer
@@ -49,26 +43,25 @@ sudo apt-get install openjdk-8-jre
 dpkg -i rskj_0.6.2~yourUbuntuVersionName_amd64.deb
 ```
 
+We recommend that you check that the SHA256 hash of the downloaded package file matches, prior to installation:
 
-Before installation, you are recommended to check the SHA256 of the downloaded package file.
+* `rskj_0.6.2_bionic_amd64.deb`: `5482fa4261d70756f5944fa907a9d73e2a13884d97d57aef2e553854d905ff16`
+* `rskj_0.6.2_bionic_i386.deb`: `68d4ce155f8171f7ad4d5a35bed7b566329f53945dadc2f6312f19f46c5d1ed1`
+* `rskj_0.6.2_trusty_amd64.deb`: `b5caa06e53774c7b1a2c5e3a54ecdfc2621fc37a597d16de7ac0a02afa6fb93b`
+* `rskj_0.6.2_trusty_i386.deb`: `fa9d10f1e902f300a98406f9575ac4e0d6172c9500384e417cf3c1157b7aadfb`
+* `rskj_0.6.2_xenial_amd64.deb`: `5eece84721d8d03179e5f3d17403b8c289c0fd6f33f5fafcef06103d5952ff2d`
+* `rskj_0.6.2_xenial_i386.deb`: `088182552ac5ea063ed2a1f4f47942a3d55fc29e29c87dc73d0c7bf9c3bf2171`
 
-```
-5482fa4261d70756f5944fa907a9d73e2a13884d97d57aef2e553854d905ff16  rskj_0.6.2_bionic_amd64.deb
-68d4ce155f8171f7ad4d5a35bed7b566329f53945dadc2f6312f19f46c5d1ed1  rskj_0.6.2_bionic_i386.deb
-b5caa06e53774c7b1a2c5e3a54ecdfc2621fc37a597d16de7ac0a02afa6fb93b  rskj_0.6.2_trusty_amd64.deb
-fa9d10f1e902f300a98406f9575ac4e0d6172c9500384e417cf3c1157b7aadfb  rskj_0.6.2_trusty_i386.deb
-5eece84721d8d03179e5f3d17403b8c289c0fd6f33f5fafcef06103d5952ff2d  rskj_0.6.2_xenial_amd64.deb
-088182552ac5ea063ed2a1f4f47942a3d55fc29e29c87dc73d0c7bf9c3bf2171  rskj_0.6.2_xenial_i386.deb
-```
+## After installation
 
-### After installation
+By default, the node connects to MainNet. To change the network choice (MainNet/ TestNet/ RegTest), refer to the instructions in [switching networks](https://github.com/rsksmart/rskj/wiki/Switching-networks). To change configurations for the node, refer to the instructions in [RSK Node Configuration](https://github.com/rsksmart/rskj/wiki/RSK-node-configuration).
 
 The installer will configure your node in the following paths:
 
-  *   /etc/rsk: the directory where the config files will be placed.
-  *   /usr/share/rsk: the directory where the RskJ JAR will be placed.
-  *   /var/lib/rsk/database: the directory where the database will be stored.
-  *   /var/log/rsk: the directory where the logs will be stored.
+* `/etc/rsk`: the directory where the config files will be placed.
+* `/usr/share/rsk`: the directory where the RskJ JAR will be placed.
+* `/var/lib/rsk/database`: the directory where the database will be stored.
+* `/var/log/rsk`: the directory where the logs will be stored.
 
 <img alt="path" class="setup-node-ubuntu" src="https://files.readme.io/01c77ce-Screen_Shot_2019-06-04_at_1.14.31_PM.png">
 
@@ -77,25 +70,29 @@ The installer will configure your node in the following paths:
 After installation, you can use the following commands to manage your node.
 
 **To start the node:**
+
 ```shell
 sudo service rsk start
 ```
 
+**To stop the node:**
 
-**To stop the node: **
 ```shell
 sudo service rsk stop
 ```
 
-**To restart the node: **
+**To restart the node:**
+
 ```shell
 sudo service rsk restart
 ```
 
 **To check the status of the node service:**
+
 ```shell
 sudo service rsk status
 ```
+
 <img alt="scripts" class="setup-node-ubuntu" src="https://files.readme.io/67dd7bd-Screen_Shot_2019-06-04_at_1.13.05_PM.png">
 
 ## Video

--- a/rsk/public-nodes.md
+++ b/rsk/public-nodes.md
@@ -1,75 +1,76 @@
 ---
 layout: rsk
-title: Use
+title: Using RSK Nodes
 ---
 
 ## Public Nodes
 
-RSK is currently providing two public nodes for testing purposes:
+RSK is currently provides two public nodes for testing purposes:
 
 ### Testnet
+
 ```
 https://public-node.testnet.rsk.co
 ```
 
 ### Mainnet
+
 ```
 https://public-node.rsk.co
 ```
 
 ## Versioning
 
-Current and previous versions are accesible through this routing:
+Current and previous versions are accessible through these routes:
 
-* `/`: version `1.0.2`.
-* `/1.1.0`, `/1.1.0/`: current version `1.1.0`.
-* `/1.0.2`, `/1.0.2/`: version `1.0.2`.
+* `/`: version `1.0.2` (deprecated)
+* `/1.0.2`, `/1.0.2/`: version `1.0.2`
+* `/1.1.0`, `/1.1.0/`: version `1.1.0` (current)
 
-Eventually, the use of only `/` will be deprecated.
-
+The use of `/` will be removed in future releases.
 
 ## Supported RPC methods
 
-These nodes are supporting the following JSON RPC methods:
+These nodes support the following JSON RPC methods:
 
 | Method |
 | ------ |
-| net_version | 
-| net_listening | 
-| net_peerCount | 
-| eth_protocolVersion | 
-| eth_hashrate | 
-| eth_mining | 
-| eth_call | 
-| eth_estimateGas| 
-| eth_gasPrice | 
-| eth_blockNumber| 
-| eth_getBalance | 
-| eth_getBlockByHash | 
-| eth_getBlockByNumber | 
-| eth_getBlockTransactionCountByHash | 
-| eth_getBlockTransactionCountByNumber | 
-| eth_getCode | 
-| eth_getStorageAt | 
-| eth_getTransactionByBlockHashAndIndex | 
-| eth_getTransactionByBlockNumberAndIndex | 
-| eth_getTransactionByHash | 
-| eth_getTransactionCount | 
-| eth_getTransactionReceipt | 
-| eth_getUncleByBlockHashAndIndex | 
-| eth_getUncleByBlockNumberAndIndex | 
-| eth_getUncleCountByBlockHash | 
-| eth_getUncleCountByBlockNumber | 
-| eth_sendRawTransaction |
+| `net_version` |
+| `net_listening` |
+| `net_peerCount` |
+| `eth_protocolVersion` |
+| `eth_hashrate` |
+| `eth_mining` |
+| `eth_call` |
+| `eth_estimateGas`|
+| `eth_gasPrice` |
+| `eth_blockNumber`|
+| `eth_getBalance` |
+| `eth_getBlockByHash` |
+| `eth_getBlockByNumber` |
+| `eth_getBlockTransactionCountByHash` |
+| `eth_getBlockTransactionCountByNumber` |
+| `eth_getCode` |
+| `eth_getStorageAt` |
+| `eth_getTransactionByBlockHashAndIndex` |
+| `eth_getTransactionByBlockNumberAndIndex` |
+| `eth_getTransactionByHash` |
+| `eth_getTransactionCount` |
+| `eth_getTransactionReceipt` |
+| `eth_getUncleByBlockHashAndIndex` |
+| `eth_getUncleByBlockNumberAndIndex` |
+| `eth_getUncleCountByBlockHash` |
+| `eth_getUncleCountByBlockNumber` |
+| `eth_sendRawTransaction` |
 
-> Note: request headers must contain `"Content-Type: application/json"`
+> **Note**: request headers must include `"Content-Type: application/json"`
 
 ## Example using `cURL`
 
 Here's an example request using `cURL` to get the Mainnet block number:
 
-```bash
-$ curl https://public-node.rsk.co\
-    -X POST -H "Content-Type: application/json"\
+```shell
+curl https://public-node.rsk.co/1.1.0/ \
+    -X POST -H "Content-Type: application/json" \
     --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```


### PR DESCRIPTION
What:

- various formatting fixes, and English corrections
- fixed links that point to rskj/wiki to point internally instead
- rearranged/ collapsed certain paragraphs

Why:

- make it easier for readers to get set up

TODO:

- several images were not self hosted, on 3rd party sites, this should be addressed separately

