### PR TITLE
docs: modify quickstart to include workaround for eip1191 checksum

### DIFF
--- a/quick-start/step2-install-truffle-and-ganache.md
+++ b/quick-start/step2-install-truffle-and-ganache.md
@@ -6,7 +6,7 @@ title: Quick Start - Step 2
 
 Truffle and Ganache provides a development environment, test framework, and asset pipeline for blockchains. 
 
-#### Install Truffle
+### Install Truffle
 
 Navigate to the `truffle` directory within the tutorial, and install its dependencies.
 
@@ -14,6 +14,20 @@ Navigate to the `truffle` directory within the tutorial, and install its depende
 cd <tutorial-root>/truffle
 npm install
 ```
+
+Let us verify that we have the correct version of truffle running.
+
+```shell
+npx truffle version
+```
+
+This should output a version that matches the version number for truffle specified
+in `<tutorial-root>/truffle/package.json`.
+
+Note that we use `npx truffle` instead of `truffle` to ensure that the version installed within this directory is used,
+not a globally installed copy of truffle.
+
+#### Truffle Network Configuration
 
 Open the `truffle-config.js` file in the truffle directory. Locate the following part under `networks`.
 This part tells Truffle how to connect to our RegNet node.
@@ -35,9 +49,41 @@ module.exports = {
 };
 ```
 
-Note that the value for `privateKey` has been hardcoded into the config file. This is something that you would **not** do normally. As this is a tutorial, and we are not on the main net, however, this is OK.
+Note that the value for `privateKey` has been hard coded into the config file.
+This is something that you would **not** do normally.
+As this is a tutorial, and we are not on the main net, this is OK.
 
-#### Install Ganache
+#### Truffle Console
+
+Truffle console is a basic interactive console connecting to a node.
+We will be using it to connect to our regtest node running locally.
+
+Type the following command into a terminal.
+
+```shell
+npx truffle console --network regtest
+```
+
+This will open a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
+in your terminal, in which you can type in commands to interact with
+the node that you have connected to, using the `web3.js` API.
+
+```javascript
+truffle(regtest)>
+```
+
+Note that the `--network` parameter identifies which network we should connect to,
+and look for the options related to that within the `truffle-config.js` file.
+We can verify this by entering the following command:
+
+```javascript
+truffle(regtest)>  web3.eth.net.getId()
+33
+```
+
+Esnure that the output is `33`, which is the network ID of the regtest node.
+
+### Install Ganache
 
 Navigate to the `ganache` directory within the tutorial, and install its dependencies.
 
@@ -46,7 +92,7 @@ cd <tutorial-root>/ganache
 npm install
 ```
 
-For Ubuntu, you may see an error in the terminal: `Gtk-Message: Failed to load module "canberra-gtk-module"`
+On Ubuntu, you may see an error in the terminal: `Gtk-Message: Failed to load module "canberra-gtk-module"`
 To fix this, install the required GTK modules which also needs to be installed.
 
 ```shell
@@ -63,7 +109,7 @@ Ganache is a GUI app, and starting it in this manner makes DevTools available.
 
 ![Ganache with DevTools](/dist/images/ganache-with-devtools.png)
 
-#### More on Truffle and Ganache
+### More on Truffle and Ganache
 
 To learn more about Truffle's commands, visit their [official website](https://www.trufflesuite.com/docs/truffle/overview).
 

--- a/quick-start/step4-compile-and-deploy.md
+++ b/quick-start/step4-compile-and-deploy.md
@@ -33,7 +33,7 @@ Change to the root of the truffle directory and then type the following command 
 
 ```shell
 cd <tutorial-root>/truffle
-truffle compile
+npx truffle compile
 ```
 
 Upon first run, all contracts will be compiled. Upon subsequent runs, Truffle will compile only the contracts that have been changed since the last compile.

--- a/quick-start/step5-run-smart-contract.md
+++ b/quick-start/step5-run-smart-contract.md
@@ -6,23 +6,21 @@ title: Quick Start - Step 5
 
 Once the smart contract has been deployed successfully. We can use Truffle console to execute its methods.
 
-#### Enter Truffle Console Mode
-
-Truffle console is a basic interactive console connecting to our local node. Type the following command into a terminal.
+Open the truffle console in your terminal using the following command.
 
 ```shell
 truffle console --network regtest
-```
 
-Note that the `--network regtest` parameter tells Truffle to connect to our local RegNet node.
+```
 
 #### Check Balance of Our EIP20 Token
 
 First, let us get the address of the account which was used to deploy the the contract.
+We shall save this in the variable `account1`.
 
 ```javascript
-accounts = await web3.eth.getAccounts()
-accounts[0]
+account1 = (await web3.eth.getAccounts())[0]
+
 ```
 
 This should print out an address, similar to `0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826`.
@@ -32,25 +30,31 @@ Now we can check its balance:
 
 ```javascript
 EIP20instance = await EIP20.deployed()
-await EIP20instance.balanceOf(accounts[0])
+
+await EIP20instance.balanceOf(account1)
 ```
 
 EIP20 is the name of our contract. This command will print out the balance of the main account as a **big number**, which should appear as `<BN: 2710>`. To see it as an integer:
 
 ```javascript
-(await EIP20instance.balanceOf(accounts[0])).toNumber()
+(await EIP20instance.balanceOf(account1)).toNumber()
+
 ```
 
 This should appear as `10000`, the number of the tokens was specified in the parameter to the constructor of the smart contract, in the truffle migration.
 
 #### Transfer Token Directly Between Two Accounts
 
-In Ganache, copy the address of the second account in the accounts tab, and then save it as a variable:
+In Ganache, copy the address of the second account in the accounts tab.
+We shall save it as a variable, `account2`:
 
 ```javascript
-account2 = '0x2e898C937f22f84a2603fb0BfDeEF43CdAC87f93'
-(await EIP20instance.balanceOf(accounts[0])).toNumber()
+account2 = web3.utils.toChecksumAddress('0x2e898C937f22f84a2603fb0BfDeEF43CdAC87f93')
+
+(await EIP20instance.balanceOf(account1)).toNumber()
+
 (await EIP20instance.balanceOf(account2)).toNumber()
+
 ```
 
 This should print out `10000` and `0` respectively - all the tokens belong to the first account, and the second account has none.
@@ -59,6 +63,7 @@ Next, use the following command to transfer some tokens from the first account t
 
 ```javascript
 await EIP20instance.transfer(account2, 10)
+
 ```
 
 This should print out an object containing transaction data.
@@ -66,8 +71,10 @@ This should print out an object containing transaction data.
 Finally, let us check the account balances to ensure that everything went smoothly:
 
 ```javascript
-(await EIP20instance.balanceOf(accounts[0])).toNumber()
+(await EIP20instance.balanceOf(account1)).toNumber()
+
 (await EIP20instance.balanceOf(account2)).toNumber()
+
 ```
 
 This should print out `9990` and `10` respectively. The first account has fewer tokens as they have been transferred to the second account.


### PR DESCRIPTION
## What

- Updated quick start instructions to
  - Include work around for incorrect checksum
  - Include self-check for correct `chainId`
  - Reshuffle sections to introduce `truffle console` in step 2, instead of waiting until step 5

## Why

- Verified that our forked version of ganache was not the root cause, and that it was indeed implementing EIP1191, not the outdated EIP55
- Verified that truffle console was indeed able to pick up the correct `chainId` (`33`)
- Therefore truffle was not internally using `chainId` properly when computing the checksum, and a work around was necessary