### PR TITLE
docs: Universal Smart Contract Interface Registry

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -113,14 +113,14 @@
                </ul>
             </li>
             <li>
-               <span class="fa fa-chevron-right"></span> 
+               <span class="fa fa-chevron-right"></span>
                <a>Architecture</a>
                <ul>
                   <li><a href="/rsk/architecture/turing-complete/">Turing complete</a></li>
                   <li><a href="/rsk/architecture/account-based/">Account based</a></li>
                   <li><a href="/rsk/architecture/2-way-peg/">2-way peg</a></li>
                   <li>
-                     <span class="fa fa-chevron-right"></span> 
+                     <span class="fa fa-chevron-right"></span>
                      <a href="/rsk/architecture/mining/">Merged mining</a>
                      <ul>
                         <li class="hide-mobile"><a href="/rsk/architecture/mining/">Merged mining</a></li>
@@ -253,7 +253,7 @@
                               <li class="hide-mobile"><a href="/rif/lumino/explorer/">Explorer</a></li>
                               <li>
                                  <span class="fa fa-chevron-right"></span>
-                                 <a href="/rif/lumino/explorer/own/">Run your own explorer</a>	
+                                 <a href="/rif/lumino/explorer/own/">Run your own explorer</a>
                                  <ul>
                                     <li class="hide-mobile"><a href="/rif/lumino/explorer/own/">Run your own explorer</a> </li>
                                     <li><a href="/rif/lumino/explorer/own/api/">Lumino Explorer API</a></li>
@@ -297,6 +297,7 @@
                      </ul>
                   </li>
                   <li><a href="/tutorials/using-blockmason/">Using Blockmason</a></li>
+                  <li><a href="/tutorials/interface-registry/">Interface Registry</a></li>
                </ul>
             </li>
             <li>

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -15,10 +15,11 @@ title: Tutorials
 
 - [Truffle Boxes](/tutorials/truffle-boxes/)
 - [rsk-starter-box](/tutorials/truffle-boxes/rsk-starter-box): This box comes with everything you need to start using smart contracts at RSK Network. It includes network configs for Mainnet and Testnet.
-- [rsk-react-webpack-box](/tutorials/truffle-boxes/rsk-react-webpack-box): In this box you'll find a basic starter pack. It includes Truffle, React and Webpack. 
+- [rsk-react-webpack-box](/tutorials/truffle-boxes/rsk-react-webpack-box): In this box you'll find a basic starter pack. It includes Truffle, React and Webpack.
 - [rsk-next-box](/tutorials/truffle-boxes/rsk-next-box): In this box you'll find a basic starter pack. It includes Truffle and Next JS.
 - [rsk-react-express-box](/tutorials/truffle-boxes/rsk-react-express-box): In this box you'll find a basic starter pack. It includes Truffle, React and Express JS.
 
 ## Other tutorials
 
 - [Using Blockmason](/tutorials/using-blockmason/)
+- [Interface Registry](/tutorials/interface-registry/)

--- a/tutorials/interface-registry.md
+++ b/tutorials/interface-registry.md
@@ -1,13 +1,13 @@
 ---
 layout: rsk
-title: Interface Registry
+title: Universal Smart Contract Interface Registry
 ---
 
-Simple Summary
 The ERC1820 standard defines a universal registry smart contract where any address (contract or regular account) can register which interface it supports and which smart contract is responsible for its implementation.
 
-Description
-This standard defines a registry where smart contracts and regular accounts can publish which functionality they implement---either directly or through a proxy contract.
+## Description
+
+This standard defines a registry where smart contracts and regular accounts can publish which functionality they implement - either directly or through a proxy contract.
 
 Anyone can query this registry to ask if a specific address implements a given interface and which smart contract handles its implementation.
 
@@ -17,29 +17,30 @@ Interfaces with zeroes (0) as the last 28 bytes are considered ERC165 interfaces
 
 This contract also acts as an ERC165 cache to reduce gas consumption.
 
-Motivation
-ERC1820 allows contracts to register interface and query the registry, avoiding miss communications that may result in the loss of funds.
-For example on ERC-20 a mistake burns the tokens
-Though the ERC-20 token is well-documented and well-implemented overall, the ERC-20 token standard has a bug. This bug has burnt tokens worth millions of US dollars. With the transfer function, you can only send tokens to the EOA account. If you use the “transfer” function, you will see a successful transaction, but the contract will never receive the tokens. This burns the tokens forever, and it can’t be retrieved. By using the wrong function, several users have lost their tokens for good!
-The ERC777 solves this problem using ERC1820 and its ERC20 compatible
+## Motivation
 
+[EIP1820](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1820.md)
+allows contracts to register interface and query the registry, avoiding miscommunications that may result in the loss of funds.
 
-Links and Information
-This is the original EIP
-https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1820.md
+For example, with an ERC20 smart contract, a mistake can result in tokens being burnt.
+Though the ERC20 token standard is well documented and well implemented overall, it contains a bug. This bug has result in losses of tokens worth millions of US dollars. With the `transfer` function, you can only send tokens to an externally account. If you use the `transfer` function to send tokens to a smart contract (which is not an externally owned account), you will see a successful transaction, but the contract will never receive the tokens. This effectively destroys the tokens forever, as they cannot be retrieved. By using the wrong function, several users have lost their tokens for good!
 
-We have deployed the ERC1820 contract on mainnet
-https://explorer.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24
+The ERC777 token standard solves this problem using the EIP1820 interface registry, and it is backward compatible with the ECR20 token standard.
 
-and testnet
-https://explorer.testnet.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24
+## Links and Information
 
-The RSKIP is:
-https://github.com/rsksmart/RSKIPs/pull/148
+Original:
 
-Example of other networks implementing it:
-https://forum.poa.network/t/just-deployed-the-erc1820-registry-on-xdai/2777
+- [EIP1820](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1820.md)
+- Comparing [ERC777 to ERC20](https://hackernoon.com/erc777-is-the-new-token-standard-replacing-the-erc20-fd6319c3b13)
+- Comparing [ERC777 and ERC223 to ERC20](https://101blockchains.com/erc20-vs-erc223-vs-erc777/)
 
-Comparisons between ERC20 and ERC777:
-https://hackernoon.com/erc777-is-the-new-token-standard-replacing-the-erc20-fd6319c3b13
-https://101blockchains.com/erc20-vs-erc223-vs-erc777/
+RSK:
+
+- [RSK Mainnet deployed EIP1820 smart contract](https://explorer.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24)
+- [RSK Testnet deployed EIP1820 smartcontract](https://explorer.testnet.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24)
+- Corresponding RSK Improvement Proposal: [RSKIP148](https://github.com/rsksmart/RSKIPs/blob/e0ac990679a2e6f476e41db0c1050132cd2b1bfc/IPs/RSKIP148.md)
+
+Implementations in other crypto-networks:
+
+- [POA](https://forum.poa.network/t/just-deployed-the-erc1820-registry-on-xdai/2777)

--- a/tutorials/interface-registry.md
+++ b/tutorials/interface-registry.md
@@ -27,6 +27,13 @@ Though the ERC20 token standard is well documented and well implemented overall,
 
 The ERC777 token standard solves this problem using the EIP1820 interface registry, and it is backward compatible with the ECR20 token standard.
 
+In order to enable implementations based on the ERC777 token standard,
+as well as any other smart contracts that would benefit from
+the use of a universal smart contract interface registry,
+RSK has deployed an implementation of the EIP1820 registry on both its
+[Mainnet](https://explorer.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24),
+and [Testnet](https://explorer.testnet.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24).
+
 ## Links and Information
 
 Original:

--- a/tutorials/interface-registry.md
+++ b/tutorials/interface-registry.md
@@ -47,7 +47,3 @@ RSK:
 - [RSK Mainnet deployed EIP1820 smart contract](https://explorer.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24)
 - [RSK Testnet deployed EIP1820 smartcontract](https://explorer.testnet.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24)
 - Corresponding RSK Improvement Proposal: [RSKIP148](https://github.com/rsksmart/RSKIPs/blob/e0ac990679a2e6f476e41db0c1050132cd2b1bfc/IPs/RSKIP148.md)
-
-Implementations in other crypto-networks:
-
-- [POA](https://forum.poa.network/t/just-deployed-the-erc1820-registry-on-xdai/2777)

--- a/tutorials/interface-registry.md
+++ b/tutorials/interface-registry.md
@@ -1,0 +1,45 @@
+---
+layout: rsk
+title: Interface Registry
+---
+
+Simple Summary
+The ERC1820 standard defines a universal registry smart contract where any address (contract or regular account) can register which interface it supports and which smart contract is responsible for its implementation.
+
+Description
+This standard defines a registry where smart contracts and regular accounts can publish which functionality they implement---either directly or through a proxy contract.
+
+Anyone can query this registry to ask if a specific address implements a given interface and which smart contract handles its implementation.
+
+This registry MAY be deployed on any chain and shares the same address on all chains.
+
+Interfaces with zeroes (0) as the last 28 bytes are considered ERC165 interfaces, and this registry SHALL forward the call to the contract to see if it implements the interface.
+
+This contract also acts as an ERC165 cache to reduce gas consumption.
+
+Motivation
+ERC1820 allows contracts to register interface and query the registry, avoiding miss communications that may result in the loss of funds.
+For example on ERC-20 a mistake burns the tokens
+Though the ERC-20 token is well-documented and well-implemented overall, the ERC-20 token standard has a bug. This bug has burnt tokens worth millions of US dollars. With the transfer function, you can only send tokens to the EOA account. If you use the “transfer” function, you will see a successful transaction, but the contract will never receive the tokens. This burns the tokens forever, and it can’t be retrieved. By using the wrong function, several users have lost their tokens for good!
+The ERC777 solves this problem using ERC1820 and its ERC20 compatible
+
+
+Links and Information
+This is the original EIP
+https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1820.md
+
+We have deployed the ERC1820 contract on mainnet
+https://explorer.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24
+
+and testnet
+https://explorer.testnet.rsk.co/address/0x1820a4b7618bde71dce8cdc73aab6c95905fad24
+
+The RSKIP is:
+https://github.com/rsksmart/RSKIPs/pull/148
+
+Example of other networks implementing it:
+https://forum.poa.network/t/just-deployed-the-erc1820-registry-on-xdai/2777
+
+Comparisons between ERC20 and ERC777:
+https://hackernoon.com/erc777-is-the-new-token-standard-replacing-the-erc20-fd6319c3b13
+https://101blockchains.com/erc20-vs-erc223-vs-erc777/


### PR DESCRIPTION
## What

- Write up what is EIP1820/ RSKIP148 and why it is needed
- Link to our deployed interface registries

## Why

- @pmprete has implemented RSKIP148, which is the equivalent of EIP1820
- The interface registry has been published on Mainnet and Testnet, and developers implementing the ERC777 token standard should use these addresses

