### PR TITLE
feat: add toggle in nav column for expand all/ collapse all

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -1,7 +1,7 @@
 <div class="menu-container">
    <span>
       <a href="/" class="index">RSK Documentation</a>
-      <div class="expand-all collapsed">
+      <div class="toggle-nav-column-visibility collapsed">
          <span class="fa fa-chevron-right"></span>
          <span class="text">Expand All</span>
       </div>

--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -1,5 +1,11 @@
 <div class="menu-container">
-   <a href="/" class="index">RSK Documentation</a>
+   <span>
+      <a href="/" class="index">RSK Documentation</a>
+      <div class="expand-all collapsed">
+         <span class="fa fa-chevron-right"></span>
+         <span class="text">Expand All</span>
+      </div>
+   </span>
    <ul class="exclude-doc-from-breadcrumbs">
       <li class="first_level">
          <span class="fa fa-chevron-right"></span>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -251,8 +251,12 @@ a:not([href]):not([tabindex]) {
 	font-family: 'Quicksand', sans-serif!important;
 	color:#CCCCCC!important;
 	font-weight:bold!important;
-	padding: 0 0 30px 0;
+	padding: 0 0 10px 0;
 	font-size:15px;
+}
+
+.expand-all {
+	padding: 0 0 30px 0;
 }
 
 .menu-container > div > a:hover {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -255,7 +255,7 @@ a:not([href]):not([tabindex]) {
 	font-size:15px;
 }
 
-.expand-all {
+.toggle-nav-column-visibility {
 	padding: 0 0 30px 0;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -64,7 +64,7 @@ $(document).ready(function () {
 $(document).ready(function () {
  $('.current').parentsUntil('.first_level').addClass('subnav-reveal rotate-chevron');
  $('.current').parents().addClass('rotate-chevron current');
- $('.expand-all').on('click', expandAll);
+ $('.toggle-nav-column-visibility').on('click', toggleNavColumnVisibility);
 });
 
 // Header scroll class
@@ -94,7 +94,7 @@ function ChangeTheme (e) {
 }
 
 // toggle between expand all and collapse all
-function expandAll (e) {
+function toggleNavColumnVisibility (e) {
   // work out whether we are expanding or collapsing
   var target = $(this);
   target.toggleClass('collapsed');

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -64,6 +64,7 @@ $(document).ready(function () {
 $(document).ready(function () {
  $('.current').parentsUntil('.first_level').addClass('subnav-reveal rotate-chevron');
  $('.current').parents().addClass('rotate-chevron current');
+ $('.expand-all').on('click', expandAll);
 });
 
 // Header scroll class
@@ -89,5 +90,26 @@ function ChangeTheme (e) {
     $(e).text('Dark');
     $('link[href="/assets/css/styles_dark.css"]').prop('disabled', true);
   }
+  return false;
+}
+
+// toggle between expand all and collapse all
+function expandAll (e) {
+  // work out whether we are expanding or collapsing
+  var target = $(this);
+  target.toggleClass('collapsed');
+  var isCollapsed = target.hasClass('collapsed');
+  var targetText = isCollapsed ? 'Expand All' : 'Collapse All';
+
+  // update the text we just clicked on
+  target.find('.text').text(targetText);
+  target.toggleClass('rotate-chevron', !isCollapsed);
+
+  // update every item in the collapsible menu
+  $('.desktop_accordion .subnav > a').each(function () {
+    $(this).parent().toggleClass('rotate-chevron', !isCollapsed);
+    $(this).next('ul').toggleClass('subnav-reveal', !isCollapsed);
+  });
+
   return false;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,87 +1,70 @@
-
 // add active class to a in inner nav based on url
 $(function () {
-var pageUrl = location.href;
-$('a').each(function () {
-$(this).toggleClass('active', this.href === pageUrl);
+  var pageUrl = location.href;
+  $('a').each(function () {
+    $(this).toggleClass('active', this.href === pageUrl);
 	});
-})
+});
 
-$(document).ready(function(){
-  $('ul li:has(ul)', ".menu-container").addClass('subnav');
-  $(".desktop_accordion .subnav > a").click(function(event){
+$(document).ready(function () {
+  $('ul li:has(ul)', '.menu-container').addClass('subnav');
+  $('.desktop_accordion .subnav > a').click(function (event) {
     event.preventDefault();
-    $(this).parent().toggleClass("rotate-chevron");
-    $(this).next('ul').toggleClass("subnav-reveal");
+    $(this).parent().toggleClass('rotate-chevron');
+    $(this).next('ul').toggleClass('subnav-reveal');
   });
 });
 
-$('a[href^="#"]').on('click', function(event) {
+$('a[href^="#"]').on('click', function (event) {
   var target = $(this.getAttribute('href'));
-  if(target.length) {
-      event.preventDefault();
-      $('html, body').stop().animate({
-          scrollTop: target.offset().top-100
-      }, 1000);
+  if (target.length) {
+    event.preventDefault();
+    $('html, body').stop().animate({
+      scrollTop: target.offset().top - 100
+    }, 1000);
   }
 });
 
-$(document).ready(function() {
-    //var path = location.href;
-    //if (path) {$('li a[href$="' + path + '"]:first').attr('class', 'current');}
-    //var crumbs = $(".current").parents("ul")
+$(document).ready(function () {
+  // set all links within the collapsible menu to not have `current`,
+  // except for the one link that points to the current page
   var pageUrl = location.href;
   $('.desktop_accordion ul li a').each(function () {
-  $(this).toggleClass('current', this.href === pageUrl);
-	});
+    $(this).toggleClass('current', this.href === pageUrl);
+  });
 
-  var crumbs = $(".current").parentsUntil(".exclude-doc-from-breadcrumbs")
-    .prev("a").add(".current")
-  .map(function() {
-    var link = $(this).attr('href');
-    var link_text = $(this).text();
-    var title = $(this).attr('title');
-    var bc = "<li><a href="+link+" title="+''+">"+link_text+"</a></li>";
-    return bc;
-  }).get().join("  ");
-  $(".breadcrumb").html(crumbs);
+  // traverse up the list of parents until we get to the top,
+  // building up the links to them along the way for use as breadcrumbs,
+  // plus setting them to `current` as well, so that they appear expanded
+  var crumbs = $('.current').parentsUntil('.exclude-doc-from-breadcrumbs')
+    .prev('a').add('.current')
+    .map(function () {
+      var link = $(this).attr('href');
+      var link_text = $(this).text();
+      var title = $(this).attr('title');
+      var bc = '<li><a href='+link+' title='+''+'>'+link_text+'</a></li>';
+      return bc;
+    }).get().join('  ');
+  $('.breadcrumb').html(crumbs);
 });
 
- $(document).ready(function() {
-var liText = '', liList = $('.breadcrumb li'), listForRemove = [];
-$(liList).each(function () {
-  var text = $(this).text();
-  if (liText.indexOf('|'+ text + '|') == -1)
-    liText += '|'+ text + '|';
-  else
-    listForRemove.push($(this));
-});
-$(listForRemove).each(function () { $(this).remove(); });
-});
-
-
-$(document).ready(function(){
- $(".current").parentsUntil(".first_level").addClass("subnav-reveal rotate-chevron");
- $(".current").parents().addClass("rotate-chevron current");
+$(document).ready(function () {
+  var liText = '', liList = $('.breadcrumb li'), listForRemove = [];
+  $(liList).each(function () {
+    var text = $(this).text();
+    if (liText.indexOf('|'+ text + '|') == -1) {
+      liText += '|'+ text + '|';
+    } else {
+      listForRemove.push($(this));
+    }
+  });
+  $(listForRemove).each(function () { $(this).remove(); });
 });
 
-
-// Header scroll class
-$(window).scroll(function () {
-	if ($(this).scrollTop() > 10) {
-		$('.navbar').addClass('header-scrolled');
-		$('.logo').addClass('header-scrolled');
-		$('.navbar-toggler-icon').addClass('header-scrolled');
-		$('.navbar_bottom_shape').addClass('header-scrolled');
-
-	} else {
-		$('.navbar').removeClass('header-scrolled');
-		$('.logo').removeClass('header-scrolled');
-		$('.navbar-toggler-icon').removeClass('header-scrolled');
-		$('.navbar_bottom_shape').removeClass('header-scrolled');
-	}
+$(document).ready(function () {
+ $('.current').parentsUntil('.first_level').addClass('subnav-reveal rotate-chevron');
+ $('.current').parents().addClass('rotate-chevron current');
 });
-
 
 // Header scroll class
 $(window).scroll(function () {
@@ -90,7 +73,6 @@ $(window).scroll(function () {
     $('.logo').addClass('header-scrolled');
     $('.navbar-toggler-icon').addClass('header-scrolled');
     $('.navbar_bottom_shape').addClass('header-scrolled');
-
   } else {
     $('.navbar').removeClass('header-scrolled');
     $('.logo').removeClass('header-scrolled');
@@ -99,13 +81,13 @@ $(window).scroll(function () {
   }
 });
 
-function ChangeTheme(e){
-	if($(e).text() ==='Dark'){
-		$(e).text('Light');
-		$('link[href="/assets/css/styles_dark.css"]').prop('disabled', false);
-	}else{
-		$(e).text('Dark');
-		$('link[href="/assets/css/styles_dark.css"]').prop('disabled', true);
-	}
-	return false;
+function ChangeTheme (e) {
+  if ($(e).text() === 'Dark') {
+    $(e).text('Light');
+    $('link[href="/assets/css/styles_dark.css"]').prop('disabled', false);
+  } else {
+    $(e).text('Dark');
+    $('link[href="/assets/css/styles_dark.css"]').prop('disabled', true);
+  }
+  return false;
 }


### PR DESCRIPTION
## What

- Added an element at the top of the nav column that toggles between "Exapnd All" and "Collapse All" when clicked
- When this happens, all items in the collapsible menu are expanded or collapsed at once

## Why

- This was requested as a means to be easily able to `Ctrl+F` find content within the menu

## Refs

- [Task](https://trello.com/c/X3hH04xf/115-devportal-add-expand-all-for-nav-column-sitemap-like)
