### PR TITLE
Fixing "use" section at "rsk blockchain > node"

### DIFF
--- a/rsk/node/index.md
+++ b/rsk/node/index.md
@@ -11,7 +11,7 @@ RskJ is a Java implementation of the [RSK blockchain](/rsk) node.
 # Learn more
 
 - [Architecture](/rsk/node/architecture/)
-- [Use](/rsk/node/public-nodes)
+- [Use](/rsk/public-nodes)
 - [Install](/rsk/node/install)
 - [Configure](/rsk/node/configure)
 - [Contribute](/rsk/node/contribute)


### PR DESCRIPTION
previous link was redirecting to a [non-existing page](https://developers.rsk.co/rsk/node/public-nodes), the actual link it's [this one](https://developers.rsk.co/rsk/public-nodes/)