### PR TITLE
fix: bug in search that was indexing non-content pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.8.3"
 gem "rouge"
-gem "jekyll-last-modified-at"
-gem "jekyll-github-metadata"
-gem "jemoji"
 source 'https://rubygems.org'
 
 require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem 'github-pages', versions['github-pages']
+gem "jekyll", "~> 3.8.5"
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-feed", "~> 0.11"
+  gem 'github-pages', "202"
+  gem "jekyll-last-modified-at"
+  gem "jekyll-github-metadata"
+  gem "jemoji"
 end
 
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,9 @@ domain: developers.rsk.co
 
 highlighter: rouge
 
+exclude:
+  - .jekyll-cache
+
 plugins:
  - jekyll-last-modified-at
  - jekyll-feed

--- a/search/search.json
+++ b/search/search.json
@@ -1,8 +1,8 @@
 ---
 skip_search: true
 ---
-{% assign pages = site.pages | where_exp: "page", "page.skip_search != true" %}
-{% assign   content_sections = "quick-start|the-stack|rsk|rif|develop|contribute" | split: "|" %}
+{% assign pages = site.pages | where_exp: "page", "page.skip_search != true" | where_exp: "page", "page.layout != 'redirect'" %}
+{% assign content_sections = "quick-start|the-stack|rsk|rif|develop|contribute" | split: "|" %}
 [
   {% for page in pages %} {% assign page_section = page.url | split: "/" %}
     {

--- a/search/search.json
+++ b/search/search.json
@@ -2,18 +2,23 @@
 skip_search: true
 ---
 {% assign pages = site.pages | where_exp: "page", "page.skip_search != true" %}
+{% assign   content_sections = "quick-start|the-stack|rsk|rif|develop|contribute" | split: "|" %}
 [
-  {% for page in pages %}
+  {% for page in pages %} {% assign page_section = page.url | split: "/" %}
     {
-      "title"    : "{{ page.title | strip_html | escape }}",
       "url"      : "{{ site.baseurl }}{{ page.url }}",
+      "title"    : "{{ page.title | strip_html | escape }}",
       "category" : "{{ page.categories | join: ', '}}",
       "tags"     : "{{ page.tags | join: ', ' }}",
       "date"     : "{{ page.date }}",
+      {% if content_sections contains page_section[1] %}
       {% if page.description %}
-      "desc" : "{{ page.description | strip_html | escape | strip_newlines | truncatewords: 200, "…" }}"
+      "desc"     : "{{ page.description | strip_html | escape | strip_newlines | truncatewords: 200, "…" }}"
       {% else %}
-      "desc" : "{{ page.content | strip_html | escape | strip_newlines | truncatewords: 200, "…" }}"
+      "desc"     : "{{ page.content | truncatewords: 200, "…" | markdownify | strip_html | normalize_whitespace | strip_newlines | escape }}"
+      {% endif %}
+      {% else %}
+      "desc"     : ""
       {% endif %}
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}


### PR DESCRIPTION
## What

- Updated template used to generated static search index JSON
  - Now whitelists content sections
  - Now removes redirect pages
  - Also strips markdown formatting and special characters
- Updated deps in Gemfile to declare jekyll plugins properly

## Why

- There were some illegal escape characters sneaking into the rendered JSON file
- Non-content files were also getting indexed
- Gemfile
  - was updated in an attempt to upgrade to Jekyll 4 in order to use boolean conditions within `where_exp`, but that was [prevented by `github-pages` gem](https://github.com/github/pages-gem/issues/651#issuecomment-566823684)
  - made `jemoji` rendering work properly

## Refs

- [Task](https://trello.com/c/Tmg3U4rH/116)
- [Support for boolean conditions in `where_exp`]( https://github.com/jekyll/jekyll/pull/6998)

