### PR TITLE
fix: re-enable disabled redirect for the quickstart page

### DIFF
--- a/_quick-start/index.md
+++ b/_quick-start/index.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /quick-start
 redirect: /quick-start/step1-install-rsk-local-node
 ---

--- a/develop/apps/index.md
+++ b/develop/apps/index.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /develop/apps
 redirect: /develop/apps/integrate
 ---

--- a/develop/index.md
+++ b/develop/index.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /develop
 redirect: /develop/apps/integrate
 ---

--- a/rif/payments/index.md
+++ b/rif/payments/index.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /rif/payments
 redirect: /rif/lumino
 ---

--- a/rif/rns/operation.md
+++ b/rif/rns/operation.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /rif/rns/operation
 redirect: /rif/rns/operations
 ---

--- a/rif/rns/operations/Migrate-a-name.md
+++ b/rif/rns/operations/Migrate-a-name.md
@@ -1,5 +1,6 @@
 ---
 layout: redirect
+permalink: /rif/rns/operations/Migrate-a-name
 redirect: /rif/rns/operations/migrate-from-auction
 title: "Migrate from auction model"
 ---

--- a/rif/rns/operations/Register-a-name-auction.md
+++ b/rif/rns/operations/Register-a-name-auction.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /rif/rns/operations/Register-a-name-auction
 redirect: /rif/rns/operations/register-auction-deprecated
 ---

--- a/rif/rns/operations/Register-a-name.md
+++ b/rif/rns/operations/Register-a-name.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /rif/rns/operations/Register-a-name
 redirect: /rif/rns/operations/register
 ---

--- a/tutorials/truffle-boxes/index.md
+++ b/tutorials/truffle-boxes/index.md
@@ -1,4 +1,5 @@
 ---
 layout: redirect
+permalink: /tutorials/truffle-boxes
 redirect: /tools/truffle/boxes
 ---


### PR DESCRIPTION
## What

- Override the `permalink` metadata attribute for the quick start `index.md`, as jekyll has a different behaviour in assigning permalinks for `.md` files processed within collections

## Why

- There is a link to `/quick-start`, and that would then redirect, however the redirect was broken with the introduction of collections

## Refs

- Fixes https://github.com/rsksmart/rsksmart.github.io/issues/75
