### PR TITLE
docs: improve token bridge documentation

### DIFF
--- a/tools/tokenbridge/bridge.md
+++ b/tools/tokenbridge/bridge.md
@@ -61,10 +61,3 @@ truffle migrate --network rskregtest
 ```
 
 This will also generate the json files for that network with the addresses of the deployed contracts that will be called by the federator.
-
-
-
-
-
-
-

--- a/tools/tokenbridge/contractaddresses.md
+++ b/tools/tokenbridge/contractaddresses.md
@@ -6,12 +6,15 @@ title: Addresses and Links
 # MainNet Addresses and Links
 
 ### On RSK
+
   - "bridge": [0x9d11937e2179dc5270aa86a3f8143232d6da0e69](https://explorer.rsk.co/address/0x9d11937e2179dc5270aa86a3f8143232d6da0e69)
   - "federation": [0xac42761c37d4467ff69082249b9e67d6b35d50cb](https://explorer.rsk.co/address/0xac42761c37d4467ff69082249b9e67d6b35d50cb)
   - "allowTokens": [0xe4aa0f414725c9322a1a9d80d469c5e234786653](https://explorer.rsk.co/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
   - "multiSigWallet": [0x040007b1804ad78a97f541bebed377dcb60e4138](https://explorer.rsk.co/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
   - "RIF": [0x2acc95758f8b5f583470ba265eb685a8f45fc9d5](https://explorer.rsk.co/address/0x2acc95758f8b5f583470ba265eb685a8f45fc9d5)
+
 ### On Ethereum
+
   - "bridge": ["0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d"](https://etherscan.io/address/0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d)
   - "federation": ["0x8c1901c031cdf42a846c0c422a3b5a2c943f4944"](https://etherscan.io/address/0x8c1901c031cdf42a846c0c422a3b5a2c943f4944)
   - "allowTokens": [0xe4aa0f414725c9322a1a9d80d469c5e234786653](https://etherscan.io/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
@@ -20,6 +23,7 @@ title: Addresses and Links
 # Testnet Addresses and Links
 
 ### On RSK Testnet
+
   - "bridge": [0x684a8a976635fb7ad74a0134ace990a6a0fcce84](https://explorer.testnet.rsk.co/address/0x684a8a976635fb7ad74a0134ace990a6a0fcce84)
   - "federation": [0x36c893a955399cf15a4a2fbef04c0e06d4d9b379](https://explorer.testnet.rsk.co/address/0x36c893a955399cf15a4a2fbef04c0e06d4d9b379)
   - "allowTokens": [0x952b706a9ab5fd2d3b36205648ed7852676afbe7](https://explorer.testnet.rsk.co/address/0x952b706a9ab5fd2d3b36205648ed7852676afbe7)
@@ -27,6 +31,7 @@ title: Addresses and Links
   - "tRIF": [0x19f64674d8a5b4e652319f5e239efd3bc969a1fe](https://explorer.testnet.rsk.co/address/0x19f64674d8a5b4e652319f5e239efd3bc969a1fe)
 
 ### On Kovan
+
   - "bridge": ["0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d"](https://kovan.etherscan.io/address/0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d)
   - "federation": ["0x8c1901c031cdf42a846c0c422a3b5a2c943f4944"](https://kovan.etherscan.io/address/0x8c1901c031cdf42a846c0c422a3b5a2c943f4944)
   - "allowTokens": [0xe4aa0f414725c9322a1a9d80d469c5e234786653](https://kovan.etherscan.io/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
@@ -34,15 +39,18 @@ title: Addresses and Links
   - "etRIF": [0x69f6d4d4813f8e2e618dae7572e04b6d5329e207](https://kovan.etherscan.io/address/0x69f6d4d4813f8e2e618dae7572e04b6d5329e207)
 
 ## List of ABIs
-[abis used](https://github.com/rsksmart/tokenbridge/tree/master/abis)
+
+[ABIs used](https://github.com/rsksmart/tokenbridge/tree/master/abis)
 
 ## RSK Testnet Explorer, Faucet and Stats
-- https://stats.testnet.rsk.co/
-- https://explorer.testnet.rsk.co/
-- https://faucet.rsk.co/
-- https://faucet.rifos.org/
+
+- [explorer.testnet.rsk.co](https://explorer.testnet.rsk.co/)
+- [stats.testnet.rsk.co](https://stats.testnet.rsk.co/)
+- [faucet.rsk.co](https://faucet.rsk.co/)
+- [faucet.rifos.org](https://faucet.rifos.org/)
 
 ## Kovan (Ethereum Testnet), Explorer and Faucet
-- https://kovan.etherscan.io/
-- https://faucet.kovan.network/
-- https://gitter.im/kovan-testnet/faucet
+
+- [kovan.etherscan.io](https://kovan.etherscan.io/)
+- [faucet.kovan.network](https://faucet.kovan.network/)
+- [gitter.im/kovan-testnet/faucet](https://gitter.im/kovan-testnet/faucet)

--- a/tools/tokenbridge/dappguide.md
+++ b/tools/tokenbridge/dappguide.md
@@ -3,23 +3,25 @@ layout: rsk
 title: Token Bridge Dapp Guide
 ---
 
-This Decentralized Application helps you to interact with the Token Bridge contracts, to safetly cross your tokens from RSK to Ethereum [https://tokenbridge.rsk.co/](https://tokenbridge.rsk.co/)
+This Decentralized Application helps you to interact with the Token Bridge contracts, to safely cross your tokens between RSK and Ethereum networks. It is available at [tokenbridge.rsk.co](https://tokenbridge.rsk.co/)
 
 ### Description
+
 This guide describes the steps to transfer tokens using the Web Interface for the RSK Tokenbridge system. Please refer to the project documentation if you’d like to know more about how this bridge works.
 
-It is possible to test the transfer of tokens between RSK and Kovan networks using the RSK Tokenbridge web interface. This will require access to a Chrome or Chromium web browser and install one the extensions [Nifty Wallet](https://chrome.google.com/webstore/detail/nifty-wallet/jbdaocneiiinmjbjlgalhcelgbejmnid) or [Metamask with custom network](https://github.com/rsksmart/rskj/wiki/Configure-Metamask-to-connect-with-RSK).
+It is possible to test the transfer of tokens between RSK and Kovan networks using the RSK Tokenbridge web interface. This will require access to either Chrome or Chromium web browser, with either [Nifty Wallet](https://chrome.google.com/webstore/detail/nifty-wallet/jbdaocneiiinmjbjlgalhcelgbejmnid) or [Metamask with custom network](https://github.com/rsksmart/rskj/wiki/Configure-Metamask-to-connect-with-RSK) wallet browser extension installed.
 
 ## Steps
-Start by connecting one of the extensions to the RSK Testnet network. If everything is correct, you will see the following:
+
+Start by connecting your wallet browser extension to the RSK Testnet network. If everything is correct, you should see the following:
 
 <img src="/assets/img/tools/tokenbridge/dapp-image1.png" />
 
-Then, locate the address of the token in RSK Testnet for which you want to transfer tokens from. For example 0x5D248F520b023acB815eDeCD5000B98ef84CbF1b
+Then, locate the address of the token in RSK Testnet from which you wish to transfer tokens. For example, `0x5D248F520b023acB815eDeCD5000B98ef84CbF1b`.
 
 <img src="/assets/img/tools/tokenbridge/dapp-image2.png" />
 
-Paste the address in the Token Address field, the token will be recognized and the symbol shown automatically. Enter the amount you want to transfer and confirm with the Cross the Tokens button. 
+Paste the address in the Token Address field, the token will be recognized and its symbol shown automatically. Enter the amount you want to transfer, and confirm with the `Cross the Tokens` button.
 
 <img src="/assets/img/tools/tokenbridge/dapp-image3.png" />
 
@@ -37,9 +39,11 @@ If the transfer is successful, a new alert is displayed
 
 <img src="/assets/img/tools/tokenbridge/dapp-image7.png" />
 
-Next, you can obtain the address associated with the token on the other network, in this case Kovan. To do this, switch from the browser extension to the Kovan network and enter the original token address. Confirm with Get Side Token Address. 
+Next, you can obtain the address associated with the token on the other network, in this case Kovan. To do this, switch from the browser extension to the Kovan network and enter the original token address. Confirm with Get Side Token Address.
 A new address that corresponds to the associated token in Kovan should appear
 
 <img src="/assets/img/tools/tokenbridge/dapp-image8.png" />
 
-This address can be used to verify the balance and confirm that the tokens were effectively transferred. In the same way, you can use it to make a cross back of tokens between the networks.
+This address can be used to verify the balance and confirm that the tokens were effectively transferred.
+
+You can transfer tokens in the other direction too, using the same method.

--- a/tools/tokenbridge/faq.md
+++ b/tools/tokenbridge/faq.md
@@ -4,53 +4,72 @@ title: Token Bridge FAQ
 ---
 
 ## What is the Token Bridge?
-The Token Bridge is an interoperability protocol which allows users to move their own RSK or Ethereum Tokens between networks in a quick and cost-efficient manner.
-The UI is available at [https://testnet.tokenbridge.rsk.co/](https://testnet.tokenbridge.rsk.co/)
+
+The Token Bridge is an interoperability protocol which allows users to move their own RSK or Ethereum ERC20 Tokens between networks in a quick and cost-efficient manner.
+The UI is available at:
+
+- Mainnet: [tokenbridge.rsk.co](https://tokenbridge.rsk.co/)
+- Testnet: [testnet.tokenbridge.rsk.co](https://testnet.tokenbridge.rsk.co/)
 
 ## What is a Side Token?
+
 Side Token is an ERC777 representation of a ERC20 tokens which is on the other network(could be  on Ethereum or RSK network). The Side Token displays the exact same properties as the standard ERC20 token and allows it to be used in all the same places that offer ERC20 compatibility.
 
 ## What is the purpose of having a Side Token?
-Side Tokens are minted to prove cross chain bridges can work in a safe and secure manner with 2 standalone blockchains. We believe this kind of  interoperability technology offers a lot of possibilities for smart contract owners, as they may prefer to do certain operations in one chain and anothers in other one. By connecting blockchains with these bridges you allow for a variety of new use cases that never existed before.
+
+Side Tokens are minted to prove cross chain bridges can work in a safe and secure manner with 2 standalone blockchains. We believe this kind of interoperability technology offers a lot of possibilities for smart contract owners, as they may prefer to do certain operations in one chain, and others in another one. By connecting blockchains with these bridges you allow for a variety of new use cases that never existed before.
 
 ## Will the supply of the original token will increase as a result of Side Tokens?
+
 No! It’s important to note that there will be no increase in the original tokens. The existing amount of circulating original tokens will stay the same and simply be distributed across 2 networks (RSK Network & Ethereum network) instead of 1.
 
 ## What is the difference between original tokens and Side Tokens?
-The original token  native tokens lives on the network that it was deployed for example Ethereum, while the Side Token is a representation of the original token on the other network, in this example Ethereum.
+
+The original token  native tokens lives on the network that it was deployed for example Ethereum, while the Side Token is a representation of the original token on the other network, for example RSK.
 
 ## What is the Side Token Contract Address, Symbol, and # of Decimal Places in order to add it as a Custom Coin on MyEtherWallet?
-The symbol of the SideToken is the original token symbol with an r prefix if it is created in RSK or an e prefix if it is created in Ethereum. For example, if we cross the RIF token to Ethereum, the Side Token symbol would be eRIF. 
-The number of Decimal places will be 18. These are the ['addresses'](/tools/tokenbridge/contractaddresses/) of the deployed contracts in the different networks.
+
+The symbol of the Side Token is the original token symbol with an `r` prefix if it is created in RSK or an `e` prefix if it is created in Ethereum. For example, if we cross the `RIF` token from RSK to Ethereum, the Side Token symbol would be `eRIF`.
+The number of decimal places will be 18. These are the ['addresses'](/tools/tokenbridge/contractaddresses/) of the deployed contracts in the different networks.
 
 ## How do I transform my original tokens to Side Tokens?
-The Token Bridge will be a public DApp where users will be able to access by using Nifty Wallet or Metamask. You will be able to send your original tokens and receive an equivalent amount of Side Tokens on the other network. By toggling the network on Nifty or Metamask, you’re also able to transfer the other way around and send Side Tokens to the original token.
+
+The Token Bridge will be a public DApp where users will be able to access by using Nifty Wallet or Metamask. You will be able to send your original tokens and receive an equivalent amount of Side Tokens on the other network. By toggling the network on Nifty or Metamask, you’re also able to transfer the other way around, by sending Side Tokens and receive original tokens.
 
 ## If I sell my Side Tokens, what happens to my original tokens?
-Upon receiving your   you no longer own your original tokens. The moment you use the bridge to send them to the other network (RSK or Ethereum), they are locked up and stored in the contract address. Thus you effectively have no original tokens on the original Network and now have Side Tokens on the other network.
+
+Upon receiving your Side Tokens, you no longer own your original tokens. The moment you use the bridge to send them to the other network (RSK or Ethereum), they are locked up and stored in the contract address. Thus you effectively have no original tokens on the original network and now have Side Tokens on the other network.
 
 ## Is there a limit on how many tokens can be bridged over?
-There is no limit, however, there is a daily quota. Hypothetically the entire circulating supply can be bridged, though this likely will never happen since there will be strong use cases to use the tokens on either network.
+
+There is no limit on the total. Hypothetically, the entire circulating supply can be bridged, though this is unlikely happen as there will be strong use cases to use the tokens on either network.
+
+However, there are daily quotas:
+
 - Daily limit: 100,000 tokens
 - Maximum per tx: 10,000 tokens
 - Minimum per tx: 1 token
 
 ## Can any token be bridged over?
-During the trial period only whitelisted tokens can cross the bridge. The federation is the responsible of adding or removing tokens to the whitelist.  When the trial period is over and we move to a fully decentralized bridge the whitelist will be removed.
+
+During the trial period, only whitelisted tokens can cross the bridge. The federation is responsible for adding and removing tokens from the whitelist.  When the trial period is over, and we move to a fully decentralized bridge, the whitelist will be removed.
 
 ## What are the fees for converting original tokens to Side Tokens and vice-versa? Who will be paying these fees?
-The federation is paying and sponsoring the fees for the multiple transactions during the trial period. This will change after the trial period is complete and the token bridge change from a federated schema to a fully decentralized one. Users will need to pay a small amount of gas fee when using Metamask for to submit their transactions.
+
+The federation is paying and sponsoring the fees for the multiple transactions during the trial period. This will change after the trial period is complete, and the token bridge changes from a federated schema to a fully decentralized one. Users will need to pay a small amount of gas fee when using Metamask for to submit their transactions.
 
 ## How many confirmations are required to convert the original tokens to Side tokens and vice-versa?
-There will 15 confirmations. On the POA Mainnet and 15 confirmations on the Ethereum network. On Sokol Testnet and Kovan Testnet, the test bridge will have 2 confirmations.
+
+15 confirmations are necessary. On the POA Mainnet and 15 confirmations on the Ethereum network. On Sokol Testnet and Kovan Testnet, the test bridge will have 2 confirmations.
 
 ## How does the Token Bridge work?
-The TokenBridge functionality is quite unique yet simple to understand. The ratio of tokens during network transfer always remains 1:1 and behaves in the following manner:
+
+The TokenBridge functionality is quite unique, yet simple to understand. The ratio of tokens during network transfer always remains 1:1 and behaves in the following manner:
 
 When original tokens are moved to the other network
 - Original tokens are locked in the Token Bridge smart contract
-- Side Tokens are minted and can move freely on the Ethereum network
+- Side Tokens are minted and can move freely on the side chain network
 
 When Side Tokens are moved back from the other network
 - Side Tokens are burned
-- Original  tokens are unlocked in the Bridge smart contract
+- Original tokens are unlocked in the Token Bridge smart contract, and can mode freely on the original network

--- a/tools/tokenbridge/federator.md
+++ b/tools/tokenbridge/federator.md
@@ -3,19 +3,21 @@ layout: rsk
 title: Federator
 ---
 
-Presents the event and necesary information to validate it on the other network
+Presents the event and necessary information to validate it on the other network
 The federator is an off-chain process which performs voting actions to validate transactions between a Mainchain (source) and a Sidechain (target) network. These transactions are obtained from the Bridge contract on the Mainchain using event logs and voted in the Sidechain through a Federation contract. Once all required signers (federators) vote for a transaction the Federation contract starts the process to release the funds on the Sidechain.
 The federators will be the owners of the contracts willing to allow to cross their tokens, and by doing so staking they reputation.
 
 ## Config
-Go to /federator/config copy `config.sample.js` file and rename it to `config.js` set mainchain and sidechain to point to the json files of the networks you are suing, for example rsktestnet-kovan.json and kovan.json, `make sure to set the host parameter of those files`. Create the file `federator.key` inside the config folder, and add the private key of the member of the Federation contract. The members of the federation are controled by the MultiSig contract, same that is owner of the Bridge and AllowedTokens contracts.
+
+Go to `/federator/config`, copy `config.sample.js` file, and rename it to `config.js`. Set `mainchain` and `sidechain` to point to the JSON files of the networks you are using, for example `rsktestnet-kovan.json` and `kovan.json`. **Make sure to set the host parameter of those files**. Create the file `federator.key` inside the config folder, and add the private key of the member of the Federation contract. The members of the federation are controled by the MultiSig contract, same that is owner of the Bridge and AllowedTokens contracts.
 
 ## Usage
+
 Run `npm install` to install the dependencies, make sure you followed the previous config step. Then to start the service run `npm start` which will start a single federator that listen to both networks. Check the logs to see that everything is working properly.
 
 ## Test
+
 You can run unit tests using `npm test`.
 To run an integration test use `npm run integrationTest`. The integration test will use a preconfigured private key (from `config.js`) which is assumed to be the only member of the Federation contract.
 In order to test with multiple federators, ensure they're added as members of the Federation contract and pass their private keys as a comma separated string for both chains as arguments of the integration test script. For instance:
 `node integrationTest.js "privKeyM1, privKeyM2, privKeyMN" "privKeyS1, privKeyS2, privKeySN"`
-

--- a/tools/tokenbridge/index.md
+++ b/tools/tokenbridge/index.md
@@ -1,40 +1,44 @@
 ---
 layout: rsk
-title: Token Bridge
+title: RSK <-> ETH Token Bridge
 ---
 
-# RSK <-> ETH Token Bridge
-
-Ethereum/RSK Bridge that allows to move ERC20 tokens from one chain to the other.
+Ethereum/RSK Bridge that allows to move ERC20 tokens between one chain and the other.
 
 ## Rationale
-Cross chain events are very important in the future of crypto. Exchanging tokens between networks allows the token holders to use them in their favorite chain without beeing restricted to the contract owner network choice. Moreover this also allows layer 2 solutions to use the same tokens on different chains, this concept together with stable coins creates a great way of payment with low volatility across networks.
+
+Cross chain events are very important in the future of cryptocurrencies. Exchanging tokens between networks allows the token holders to use them in their favorite chain without being restricted to the network choice of the contract owner. Moreover, this also allows layer 2 solutions to use the same tokens on different chains. The combination of token bridges and stable coins creates a great way of payment with low volatility across networks.
 
 ## Overview
-We have a smart contract bridge on each network, the bridge on one chain will receive and lock the tokens, then it will emmit an event that will be served to the bridge on the other chain. There is a Federation in charge of sending the event from one contract to the other.
-See the [FAQ](/tools/tokenbridge/faq/) to know more about how it works!
 
-The bridge contracts are upgradeable as we want to move to a decentralized bridge in the future. Here is the first 
+We have a smart contract bridge on each network, the bridge on one chain will receive and lock the tokens, then it will emit an event that will be served to the bridge on the other chain. There is a Federation in charge of sending the event from one contract to the other.
+See the [FAQ](/tools/tokenbridge/faq/) to learn more about how it works!
+
+The bridge contracts are upgradeable as we wish to move to a decentralized bridge in the future. Here is the first
 [POC of the trustless decentralized bridge](https://github.com/rsksmart/tokenbridge/releases/tag/decentralized-poc-v0.1)
 
 ## Usage
+
 You can use the ['Token Bridge Dapp'](https://tokenbridge.rsk.co/) together with [Nifty Wallet](https://chrome.google.com/webstore/detail/nifty-wallet/jbdaocneiiinmjbjlgalhcelgbejmnid) or [Metamask with custom network](https://github.com/rsksmart/rskj/wiki/Configure-Metamask-to-connect-with-RSK) to move tokens between networks. This is the [Dapp guide](/tools/tokenbridge/dappguide/) if you don't know how to use it.
-Or you can use a wallet or web3js with the abi of the contracts. See the ['interaction guide using MyCrypto'](/tools/tokenbridge/usingmycrypto/) for more information on how to use the bridge.
+Alternatively, you can use a wallet or web3js with the ABI of the contracts. See ['interaction guide using MyCrypto'](/tools/tokenbridge/usingmycrypto/) for more information on how to use the bridge.
 
 
 ## Developers
 
 ### Contracts
-The smart contracts used by the bridge and the deploy instructions are on the ['bridge folder'](/tools/tokenbridge/bridge/)
+
+The smart contracts used by the bridge and the deploy instructions are in the ['bridge folder'](/tools/tokenbridge/bridge/).
 The ABI to interact with the contracts are in the ['abis folder'](https://github.com/rsksmart/tokenbridge/tree/master/abis)
-Here are the ['addresses'](/tools/tokenbridge/contractaddresses/) of the deployed contrats in the different networks.
+Here are the ['addresses'](/tools/tokenbridge/contractaddresses/) of the deployed contracts in the different networks.
 
 ### Federation
-There is a federation  in charge of notifying the events that happend in the bridge of one chain to the other. The federation is composed by creators of the token contracts that wants to enable their token for crossing.
+
+There is a federation in charge of notifying the events that have happened in the bridge between one chain and the other. The federation is composed of the creators of the token contracts who want to enable their token for crossing.
 See the ['federator'](/tools/tokenbridge/federator/) for more information about the federator.
 
-To run the federator using Docker first, go to the /federator/config folder and rename `config.sample.js` to `config.js`. In that file you will dedcide the networks the federate must be listening, for example for the bridge in testnet a federator config.js will look like
-```
+To run the federator using Docker, first go to the `/federator/config` folder and rename `config.sample.js` to `config.js`. In that file you will decide the networks the federation should listen to. For example, for the bridge in Testnet, a federator `config.js` will look like
+
+```javascript
 module.exports = {
     mainchain: require('./rsktestnet-kovan.json'),
     sidechain: require('./kovan.json'),
@@ -44,10 +48,12 @@ module.exports = {
     storagePath: './db'
 }
 ```
-where the mainchain is rsktestnet and the sidechain is kovan, the .json files are in the /federator/config folder and includes the addresses of the contracts in that network and the block number when they where deployed.
-The order of sidechain and mainchain is not important is just which one is going to be checked first, as federators are bi directionals.
-Inside the .json files there is also the host to that network, for example this is the rsktestnet-kovan.json
-```
+
+&hellip; where the `mainchain` is `rsktestnet` and the `sidechain` is `kovan`, the JSON files are in the `/federator/config` folder, and includes the addresses of the contracts in that network and the block number in which they were deployed.
+The order of `sidechain` and `mainchain` is not important, as federators are bi-directional.
+The JSON files also reference the host for each network. For example, this is the `rsktestnet-kovan.json`
+
+```json
 {
     "bridge": "0x684a8a976635fb7ad74a0134ace990a6a0fcce84",
     "federation": "0x36c893a955399cf15a4a2fbef04c0e06d4d9b379",
@@ -58,9 +64,10 @@ Inside the .json files there is also the host to that network, for example this 
     "fromBlock": 434075
 }
 ```
-You need to change `"<YOUR NODE HOST AND RPC PORT>"` for the url of your node for that network and the json rpc port. `Remember to do it for both networks`.
-Also you need to create a `federetaros.key` file with the federator private in it.
-Once you have  changed this configurations create the docker image using.
+
+You need to change `"<YOUR NODE HOST AND RPC PORT>"` to the URL of your node for that network and the JSON-RPC port. **Remember to do it for both networks**.
+Also you need to create a `federetaros.key` file with the federator's private key in it.
+Once you have changed the configuration, create the docker image using.
 `docker build . -t fed-tokenbridge`
 
 Then run `docker run --rm -v $PWD/federator/config:/app/federator/config --name=fed-tokenbridge fed-tokenbridge:latest` to start the image.

--- a/tools/tokenbridge/usingmycrypto.md
+++ b/tools/tokenbridge/usingmycrypto.md
@@ -3,7 +3,7 @@ layout: rsk
 title: Interaction guide using MyCrypto
 ---
 
-This guide describes the necessary steps to perform a token transfer between two blockchain networks, hereinafter referred to as **Mainchain** and **Sidechain**, through interaction with special contracts that make up a subsystem called **TokenBridge**.
+This guide describes the necessary steps to perform a token transfer between two blockchain networks, which we will refer to to as **Mainchain** and **Sidechain**, through interaction with special contracts that make up a subsystem called **TokenBridge**.
 
 The test performed uses the RSK (with a local regtest node) and Ethereum (through the Ganache client) nodes as Mainchain and Sidechain respectively. The demonstration images to interact with both Blockchain were taken from the MyCrypto application. Alternatively, MyEtherWallet or similar can be used which will give the same results.
 
@@ -78,7 +78,7 @@ Next, access the Bridge contract in the Mainchain, entering its address (which i
 
 ---
 
-On this occasion invoke the receiveTokens method placing the IER20 contract address in the tokenToUse input and the amount in unit of wei that we wish to receive.
+On this occasion, invoke the `receiveTokens` method placing the IERC20 contract address in the `tokenToUse` input, and the amount, in wei, that we wish to receive.
 
 !["Contract Receive"](/assets/img/tools/tokenbridge/contract_receive.png "Contract Receive")
 
@@ -90,14 +90,13 @@ Again, write, sign and confirm the transaction and wait for it to be approved.
 
 ---
 
-Once this transaction  is processed on Bridge contract, the federator service will identify the event and cross the information to the Sidechain. The federator might be configured to wait a few blocks before transferring transactions.
-
+Once this transaction  is processed on Bridge contract, the federator service will identify the event and cross the information to the Sidechain. The federator may be configured to wait a few blocks before transferring transactions.
 
 ## Switch networks
 
 The next step is to connect the Blockchain interface client to the Sidechain, where the tokens will be received. In this case we use the Ganache client with the corresponding contracts previously deployed.
 
-Then connect to the Bridge's Sidechain contract using the corresponding address and JSON ABI once again. This time call the mappedTokens method passing as a parameter the address of the IERC20 contract of the Mainchain that was previously used. The result of this operation will be the address of the associated contract on the Sidechain that holds the transferred tokens.
+Then connect to the Bridge's Sidechain contract using the corresponding address and JSON ABI once again. This time call the `mappedTokens` method, passing as a parameter the address of the IERC20 contract of the Mainchain that was previously used. The result of this operation will be the address of the associated contract on the Sidechain that holds the transferred tokens.
 
 !["Contract Mapped Tokens"](/assets/img/tools/tokenbridge/contract_mapped_tokens.png "Contract Mapped Tokens")
 
@@ -105,7 +104,7 @@ Then connect to the Bridge's Sidechain contract using the corresponding address 
 
 ## Validating result
 
-Using the obtained address from the previous step (`0x1684e1C7bd0225917C48F60FbdC7f47b2982a3C2`) and the IER20 ABI interface, let’s connect to the contract.
+Using the address obtained from the previous step (`0x1684e1C7bd0225917C48F60FbdC7f47b2982a3C2`), and the IERC20 ABI interface, let’s connect to the contract.
 
 !["Access Contract Sidetoken"](/assets/img/tools/tokenbridge/access_contract_sidetoken.png "Access Contract Sidetoken")
 


### PR DESCRIPTION
## What

- Improve English, and fix markdown errors
- Note that this addresses several, but not all, of the comments left on the already merged PR #90 

## Why

- Better documentation!

## Refs

- [Comments](https://github.com/rsksmart/rsksmart.github.io/pull/90#pullrequestreview-337537363) on original PR