### PR TITLE
reproducible + security chain pages

### DIFF
--- a/_rsk/node/reproducible.md
+++ b/_rsk/node/reproducible.md
@@ -1,0 +1,96 @@
+---
+layout: rsk
+title: Reproducible Build
+collection_order: 2500
+permalink: /rsk/node/contribute/reproducible/
+---
+
+Gradle building
+===============	
+
+*Setup instructions for gradle build in docker container.*	
+
+This is a deterministic build process used to build RSK node JAR file. It provides a way to be reasonable sure that the JAR is built from GitHub RskJ repository. It also makes sure that the same tested dependencies are used and statically built into the executable.	
+
+It's strongly suggested to follow the steps by yourself to avoid any kind of contamination in the process.	
+
+Table of Contents	
+-----------------	
+- [Install Docker](#install-docker)	
+- [Build the environment docker container](#build-container)	
+- [Run Build](#run-build)	
+- [Check Results](#check-results)	
+
+Install Docker	
+--------------	
+Depending on your OS, you can install Docker following the official Docker guide:	
+
+- [Mac](https://docs.docker.com/docker-for-mac/install/)	
+- [Windows](https://docs.docker.com/docker-for-windows/install/)	
+- [Ubuntu](https://docs.docker.com/engine/installation/linux/ubuntu/)	
+- [CentOS](https://docs.docker.com/engine/installation/linux/centos/)	
+- [Fedora](https://docs.docker.com/engine/installation/linux/fedora/)	
+- [Debian](https://docs.docker.com/engine/installation/linux/debian/)	
+- [Others](https://docs.docker.com/engine/installation/#platform-support-matrix)	
+
+Build Container	
+---------------	
+Create a ```Dockerfile``` to setup the build environment	
+
+```Dockerfile	
+FROM ubuntu:16.04	
+RUN apt-get update -y && \	
+    apt-get install -y git curl gnupg-curl openjdk-8-jdk && \	
+    rm -rf /var/lib/apt/lists/* && \	
+    apt-get autoremove -y && \	
+    apt-get clean	
+RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4	
+RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4	
+RUN git clone --single-branch --depth 1 --branch WASABI-1.1.0 https://github.com/rsksmart/rskj.git /code/rskj	
+WORKDIR /code/rskj	
+RUN gpg --verify SHA256SUMS.asc	
+RUN sha256sum --check SHA256SUMS.asc	
+RUN ./configure.sh	
+RUN ./gradlew clean build -x test	
+```	
+
+If you are not familiar with Docker or the ```Dockerfile``` format: what this does is use the Ubuntu 16.04 base image and install ```git```, ```curl```, ```gnupg-curl``` and ```openjdk-8-jdk```, required for building RSK node.	
+
+
+Run build	
+---------	
+
+To create a reproducible build, run:	
+
+```bash	
+sudo docker build -t rskj-wasabi-1.1.0-reproducible .	
+```	
+
+This may take several minutes to complete. What is done is:	
+- Place in the RskJ repository root because we need Gradle and the project.	
+- Runs the [secure chain verification process](/rsk/node/security-chain/).	
+- Compile a reproducible RskJ node.	
+- `./gradlew clean build -x test` builds without running tests.	
+
+
+To obtain SHA-256 checksums, run the following command:	
+
+```bash	
+sudo docker run --rm rskj-wasabi-1.1.0-reproducible sha256sum /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI-all.jar /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI-sources.jar /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI.jar /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI.pom	
+```	
+
+Check Results	
+-------------	
+After running the build process, a JAR file will be created in ```/code/rskj-core/build/libs/```, into the docker container.	
+
+You can check the SHA256 sum of the result file and compare it to the one published by RSK for that version.	
+```bash	
+20a82720dd39864ae3603b7eb777ed454e4577c7d984b9560017fc4ddd820924 /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI-all.jar	
+0f76a447ecdf7a78c990293a90388c3a316996e66ecc670bb59a0ece3d237dcc /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI-sources.jar	
+d233feac37d6e5daca2ffa78d4ece4a3e00fe9ebbca00d0fdf862addc5564fcf /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI.jar	
+1aa633056a24056d0e50d310d1b000595205b46d1a449d63c1cf6381b9257960 /code/rskj/rskj-core/build/libs/rskj-core-1.1.0-WASABI.pom	
+```	
+
+For SHA256 sum of older versions check the [releases page](https://github.com/rsksmart/rskj/releases).	
+
+If you check inside the JAR file, you will find that the dates of the files are the same as the version commit you are using.

--- a/_rsk/node/security-chain.md
+++ b/_rsk/node/security-chain.md
@@ -1,0 +1,73 @@
+---
+layout: rsk
+title: Ensure security chain of RskJ source code
+collection_order: 2500
+permalink: /rsk/node/contribute/security-chain/
+---
+
+# Verify authenticity of RskJ source code and its binary dependencies
+
+The authenticity of the source code must be verified by checking the signature of the release tags in the official Git repository. The authenticity of the binary dependencies is verified by Gradle after following the steps below to install the necessary plugins.	
+
+## Download RSK Release Signing Key public key	
+
+For Linux based OS (Ubuntu for example) it's recommended to install `curl` and `gnupg-curl` in order to download the key through HTTPS.	
+We recommend using GPG v1 to download the public key because GPG v2 has problems to connect to HTTPS key servers. You can also download the key using curl, wget or a web browser but always check the fingerprint before importing it. 	
+
+``` bash	
+$ gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 5DECF4415E3B8FA4	
+gpg: requesting key 5E3B8FA4 from https server secchannel.rsk.co	
+gpg: key 5E3B8FA4: public key "RSK Release Signing Key <support@rsk.co>" imported	
+gpg: Total number processed: 1	
+gpg:               imported: 1  (RSA: 1)	
+```	
+
+## Verify the fingerprint of the public key	
+``` bash	
+$ gpg --finger 5DECF4415E3B8FA4	
+pub   4096R/5E3B8FA4 2017-05-16 [expires: 2022-05-15]	
+      Key fingerprint = 1A92 D894 2171 AFA9 51A8  5736 5DEC F441 5E3B 8FA4	
+uid                  RSK Release Signing Key <support@rsk.co>	
+sub   4096R/A44DCC86 2017-05-16 [expires: 2022-05-15]	
+sub   4096R/5E488E87 2017-05-16 [expires: 2022-05-15]	
+sub   4096R/9FC3E7C2 2017-05-16 [expires: 2022-05-15]	
+```	
+
+## Verify the signature of SHA256SUMS.asc	
+
+The file`SHA256SUMS.asc` is signed with RSK public key and includes SHA256 hashes of the files necessary to start the build process.	
+
+```bash	
+$ gpg --verify SHA256SUMS.asc 	
+gpg: Signature made mar 16 may 2017 16:47:56 ART	
+gpg:                using RSA key 0x67D06695A44DCC86	
+gpg: Good signature from "RSK Release Signing Key <support@rsk.co>" [ultimate]	
+Primary key fingerprint: 1A92 D894 2171 AFA9 51A8  5736 5DEC F441 5E3B 8FA4	
+     Subkey fingerprint: D135 DDC0 B54D 6EF3 5901  52DF 67D0 6695 A44D CC86	
+```	
+*Note:* you can read [this page](https://www.gnupg.org/gph/en/manual/x334.html) to know more about key management.	
+
+## Verification of binary dependencies	
+
+The authenticity of the script `configure.sh` is checked using the `sha256sum` command and the signed `SHA256SUM.asc` file. The script is used to download and check the authenticity of the Gradle Wrapper and Gradle Witness plugins. After these plugins are installed, the authenticity of the rest of the binary dependencies is checked by Gradle.	
+
+Linux - Windows (bash console)	
+```bash	
+$ sha256sum --check SHA256SUMS.asc 	
+configure.sh: OK	
+sha256sum: WARNING: 19 lines are improperly formatted	
+```	
+
+MacOs	
+```bash   	
+$ shasum --check SHA256SUMS.asc	
+configure.sh: OK	
+sha256sum: WARNING: 19 lines are improperly formatted	
+```	
+
+*Note:* if you are collaborating on this project with Git, it might produce unexpected results beacuse the way it's configured to handle line endings. See [here](https://help.github.com/articles/dealing-with-line-endings/#platform-windows) how to solve the problem.	
+
+## Run configure script to configure secure environment	
+```bash	
+$ ./configure.sh	
+ ```


### PR DESCRIPTION
## What

- adding reproducible build + security chain pages

## Why

- they were present in the RSKj Wiki and weren´t migrated before.

