### PR TITLE
feat: quick search

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -524,5 +524,18 @@
    </ul>
    <div class="nav-search-item">
       <a href="/search/" target="_blank">Search</a>
+      <form id="quick-search" action="/search/" method="GET">
+         <div class="container">
+            <div class="row">
+               <div class="col-lg-10">
+                  <input type="text" id="q" name="q" value="">
+                  <input type="hidden" id="from" name="from" value="">
+               </div>
+               <div class="col-lg-2">
+                  <button>🔍</button>
+               </div>
+            </div>
+         </div>
+      </form>
    </div>
 </div>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,8 @@
+$(document).ready(function () {
+  setUpQuickSearch();
+  setUpMainSearch();
+});
+
 // add active class to a in inner nav based on url
 $(function () {
   var pageUrl = location.href;
@@ -112,4 +117,47 @@ function toggleNavColumnVisibility (e) {
   });
 
   return false;
+}
+
+// search
+function setUpQuickSearch () {
+  // quick search is available on all pages
+  $('form#quick-search input#from').val(window.location.pathname);
+}
+
+function setUpMainSearch () {
+  if (document.location.pathname.indexOf('/search/') !== 0) {
+    // only relevant on the search page
+    return;
+  }
+  const searchInput = document.getElementById('search-input');
+  const resultsContainer = document.getElementById('results-container');
+
+  $.getJSON('/search/search.json', function (searchJson) {
+    // defer initialisation of search feature until *after*
+    // we have loaded the search JSON manually,
+    // because search feature does not provide event or callback
+    // to signal completion of asynchronous load of data
+    const search = SimpleJekyllSearch({
+      searchInput,
+      resultsContainer,
+      json: searchJson,
+      limit: 15,
+      fuzzy: true,
+    });
+    try {
+      // if quick search has been used, use query parameters in URL to
+      // perform search immediately
+      const queryParams = (new URL(document.location)).searchParams;
+      const q = queryParams.get('q');
+      if (typeof q !== 'undefined') {
+        searchInput.value = q;
+        setTimeout(function () {
+          search.search(q);
+        }, 0);
+      }
+    } catch (ex) {
+      // do nothing
+    }
+  });
 }

--- a/search/index.html
+++ b/search/index.html
@@ -12,12 +12,3 @@ skip_search: true
 
 <!-- Script pointing to search-script.js -->
 <script src="search.js" type="text/javascript"></script>
-
-<!-- Configuration -->
-<script>
-  SimpleJekyllSearch({
-    searchInput: document.getElementById('search-input'),
-    resultsContainer: document.getElementById('results-container'),
-    json: '/search/search.json'
-  });
-</script>


### PR DESCRIPTION
## What

- Search box on all pages, to enable search from anywhere, instead of only on one dedicated page
- Modify main search detect and use quick search query params

## Why

- Save clicks and improve user experience

## Refs

- [Task](https://trello.com/c/PH5zZjfB/161)
- Related issues: [#120](https://github.com/rsksmart/rsksmart.github.io/issues/120)
