### PR TITLE
updating node version

### DIFF
--- a/_rsk/public-nodes.md
+++ b/_rsk/public-nodes.md
@@ -28,7 +28,6 @@ Current and previous versions are accessible through these routes:
 * `/`: version `1.2.1` (deprecated)
 * `/1.2.1`, `/1.2.1/`: version `1.2.1` (current)
 
-The use of `/` will be removed in future releases.
 
 ## Supported RPC methods
 

--- a/_rsk/public-nodes.md
+++ b/_rsk/public-nodes.md
@@ -25,9 +25,8 @@ https://public-node.rsk.co
 
 Current and previous versions are accessible through these routes:
 
-* `/`: version `1.0.2` (deprecated)
-* `/1.0.2`, `/1.0.2/`: version `1.0.2`
-* `/1.1.0`, `/1.1.0/`: version `1.1.0` (current)
+* `/`: version `1.2.1` (deprecated)
+* `/1.2.1`, `/1.2.1/`: version `1.2.1` (current)
 
 The use of `/` will be removed in future releases.
 


### PR DESCRIPTION
## What

- updating rsk public node versioning

## Why

- last rskj node release (1.2.1)
