### PR TITLE
feat: href external

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,6 @@ group :jekyll_plugins do
   gem "jekyll-last-modified-at", "1.2.1"
   gem "jekyll-github-metadata", "2.12.1"
   gem "jemoji", "0.10.2"
+  gem "jekyll-target-blank", "2.0.0" if ENV["RAKE_BUILD_FOR"] == "prod"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,9 @@ GEM
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
     jekyll-swiss (0.4.0)
+    jekyll-target-blank (2.0.0)
+      jekyll (>= 3.0, < 5.0)
+      nokogiri (~> 1.10)
     jekyll-theme-architect (0.1.1)
       jekyll (~> 3.5)
       jekyll-seo-tag (~> 2.0)
@@ -260,7 +263,6 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
-    wdm (0.1.1)
     yell (2.2.1)
 
 PLATFORMS
@@ -275,10 +277,10 @@ DEPENDENCIES
   jekyll-feed (= 0.11)
   jekyll-github-metadata (= 2.12.1)
   jekyll-last-modified-at (= 1.2.1)
+  jekyll-target-blank (= 2.0.0)
   jemoji (= 0.10.2)
   rake (= 13.0.1)
   rouge (= 3.11.0)
-  wdm (= 0.1.1)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ SEARCH_JSON_PATH = "./_site/search/search.json"
 desc "build site for production purposes"
 task :build_for_prod => [] do |task|
   puts "rake> " + task.name + ": " + task.comment
+  ENV["RAKE_BUILD_FOR"] = "prod"
   sh "bundle exec jekyll build --config \"_config.yml\""
   puts "rake> " + task.name + ": OK!"
 end
@@ -30,12 +31,14 @@ end
 desc "development mode where site is rebuilt each time a file is saved"
 task :dev => [] do |task|
   puts "rake> " + task.name + ": " + task.comment
+  ENV["RAKE_BUILD_FOR"] = "dev"
   sh "bundle exec jekyll serve --trace --config \"_config.yml,_config.localhost.yml\""
 end
 
 desc "build site for testing purposes"
 task :build_for_test => [] do |task|
   puts "rake> " + task.name + ": " + task.comment
+  ENV["RAKE_BUILD_FOR"] = "dev"
   sh "bundle exec jekyll build --config \"_config.yml,_config.localhost.yml\""
   puts "rake> " + task.name + ": OK!"
 end

--- a/_config.localhost.yml
+++ b/_config.localhost.yml
@@ -1,1 +1,2 @@
 domain: "localhost:4000"
+url: "http://localhost:4000"

--- a/_config.yml
+++ b/_config.yml
@@ -22,11 +22,17 @@ permalink: pretty
 
 repository: rsksmart/rsksmart.github.io
 
-domain: developers.rsk.co
+domain: "developers.rsk.co"
+url: "https://developers.rsk.co"
 
 highlighter: rouge
 
 github: [metadata]
+
+target-blank:
+  add_css_classes: external-link
+  noopener: false
+  noreferrer: false
 
 exclude:
   - .jekyll-cache

--- a/_includes/actionbar.html
+++ b/_includes/actionbar.html
@@ -9,7 +9,7 @@
           <li><a class="share-linkedin" data-bi-name="linkedin" href="https://www.linkedin.com/cws/share?url=https%3A%2F%2F{{ site.domain }}{{ page.url }}"><span class="docon docon-brand-linkedin" aria-hidden="true"></span>LinkedIn</a></li>
           <li><a class="share-facebook" data-bi-name="facebook" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2F{{ site.domain }}{{ page.url }}"><span class="docon docon-brand-facebook" aria-hidden="true"></span>Facebook</a></li>
           <li><a class="share-email" data-bi-name="email" href="mailto:?subject={{ page.title }}&amp;body={{ page.title }}%0A%0Ahttps%3A%2F%2F{{ site.domain }}{{ page.url }}"><span class="docon docon-mail-message-fill" aria-hidden="true"></span>Email</a></li>
-          <li><a class="share-link" data-bi-name="link" href="#" onclick="var el = $(document.createElement('input'));$('body').append(el);el.val('https://{{ site.domain }}{{ page.url }}').select();document.execCommand('copy');$(el).remove(); return false;"><span class="docon docon-clipboard-message-fill" aria-hidden="true"></span>Copy link</a></li>
+          <li><a class="share-link" data-bi-name="link" href="#" onclick="var el = $(document.createElement('input'));$('body').append(el);el.val('{{ site.url }}{{ page.url }}').select();document.execCommand('copy');$(el).remove(); return false;"><span class="docon docon-clipboard-message-fill" aria-hidden="true"></span>Copy link</a></li>
        </ul>
     </div> |
     <a href="#" onclick="return ChangeTheme(this);">Dark</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,29 +1,29 @@
 <!-- Navigation -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-    <div class="container">
-       <a class="navbar-brand" href="https://rsk.co"><img id="logo" src="/assets/img/rsk_logo.svg" class="logo" alt="RSK Developers Portal"></a>
-       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
-       <span class="navbar-toggler-icon"></span>
-       </button>
-       <div class="collapse navbar-collapse" id="navbarResponsive">
-          <ul class="navbar-nav ml-auto">
-             <li class="nav-item">
-                <a class="nav-link" href="/the-stack" target="_self">The Stack
-                </a>
-             </li>
-             <li class="nav-item">
-                <a class="nav-link" href="/develop" target="_self">Develop</a>
-             </li>
-             <li class="nav-item">
-                <a class="nav-link" href="https://www.rsk.co/development-roadmap" target="_blank">Roadmap</a>
-             </li>
-             <li class="nav-item">
-                <a class="nav-link" href="https://fund.rsk.co" target="_blank">Ecosystem Fund</a>
-             </li>
-             <li class="nav-item">
-                <a class="nav-link" href="https://rsk.co/defi" target="_blank">Defi</a>
-             </li>
-          </ul>
-       </div>
+  <div class="container">
+    <a class="navbar-brand" href="https://rsk.co"><img id="logo" src="/assets/img/rsk_logo.svg" class="logo" alt="RSK Developers Portal"></a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarResponsive">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="/the-stack" target="_self">The Stack
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/develop" target="_self">Develop</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://www.rsk.co/development-roadmap" target="_blank">Roadmap</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://fund.rsk.co" target="_blank">Ecosystem Fund</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://rsk.co/defi" target="_blank">Defi</a>
+        </li>
+      </ul>
     </div>
- </nav>
+  </div>
+</nav>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,7 +13,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <meta name="description" content="RSK is the first open source Smart Contract platform secured by the Bitcoin Network. RSK adds value and expand functionality to the Bitcoin ecosystem by providing smart contracts and greater scalability.">
       <meta name="author" content="RSK Developers Portal">
-      <link rel="canonical" href="https://{{ site.domain }}{{ page.url }}">
+      <link rel="canonical" href="{{ site.url }}{{ page.url }}">
    	<title>RSK Developers Portal</title>
       <!-- Favicons -->
       <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicons/apple-touch-icon.png">
@@ -46,9 +46,9 @@
          height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
       <!-- Navigation -->
-      
+
       {% include header.html %}
-      
+
       <div class="navbar_bottom_shape"></div>
       <!-- Page Content -->
       <!-- home -->
@@ -85,7 +85,7 @@
       </section>
 
       {% include footer.html %}
-      
+
       <a href="#top" class="scrollup"><p>Go to top</p></a>
       <!-- Bootstrap core JavaScript -->
       <script src="/assets/vendor/jquery/jquery.min.js"></script>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="canonical" href="https://{{ site.domain }}{{ page.redirect }}">
-    <meta http-equiv="refresh" content="0; URL=//{{ site.domain }}{{ page.redirect }}">
+    <link rel="canonical" href="{{ site.url }}{{ page.redirect }}">
+    <meta http-equiv="refresh" content="0; URL={{ site.url }}{{ page.redirect }}">
     <title>Redirecting...</title>
   </head>
   <body>
     <h1>Redirecting...</h1>
-    <a href="//{{ site.domain }}{{ page.redirect }}">Click here</a> if you are not redirected.
+    <a href="{{ site.url }}{{ page.redirect }}">Click here</a> if you are not redirected.
   </body>
 </html>

--- a/_layouts/rsk.html
+++ b/_layouts/rsk.html
@@ -13,7 +13,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <meta name="description" content="RSK is the first open source Smart Contract platform secured by the Bitcoin Network. RSK adds value and expand functionality to the Bitcoin ecosystem by providing smart contracts and greater scalability.">
       <meta name="author" content="RSK Developers Portal">
-      <link rel="canonical" href="https://{{ site.domain }}{{ page.url }}">
+      <link rel="canonical" href="{{ site.url }}{{ page.url }}">
    	<title>{{ page.title }} - RSK Developers Portal</title>
       <!-- Favicons -->
       <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicons/apple-touch-icon.png">
@@ -45,9 +45,9 @@
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-56J7JTD"
          height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
-      
+
       {% include header.html %}
-      
+
       <div class="navbar_bottom_shape"></div>
       <!-- Page Content -->
       <!-- home -->
@@ -75,9 +75,9 @@
             </div>
          </div>
       </section>
-      
+
       {% include footer.html %}
-      
+
       <a href="#top" class="scrollup"><p>Go to top</p></a>
       <!-- Bootstrap core JavaScript -->
       <script src="/assets/vendor/jquery/jquery.min.js"></script>

--- a/_layouts/rsk_3col.html
+++ b/_layouts/rsk_3col.html
@@ -13,7 +13,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <meta name="description" content="RSK is the first open source Smart Contract platform secured by the Bitcoin Network. RSK adds value and expand functionality to the Bitcoin ecosystem by providing smart contracts and greater scalability.">
       <meta name="author" content="RSK Developers Portal">
-      <link rel="canonical" href="https://{{ site.domain }}{{ page.url }}">
+      <link rel="canonical" href="{{ site.url }}{{ page.url }}">
    	<title>{{ page.title }} - RSK Developers Portal</title>
       <!-- Favicons -->
       <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicons/apple-touch-icon.png">
@@ -41,7 +41,7 @@
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-56J7JTD"
          height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
-      
+
       {% include header.html %}
 
       <div class="navbar_bottom_shape"></div>
@@ -49,9 +49,9 @@
       <!-- home -->
       <section id="home">
          <div class="container">
-            
+
             {% include header-inner.html %}
-            
+
             <div class="row">
                <!-- left col desktop -->
                <div class="col-lg-3 main-left-col">


### PR DESCRIPTION
## What

- Add dependency jekyll-target-blank
- Convert all links to external links via jekyll-target-blank - only for prod builds

## Why

- Improve documentation experience
- Currently, when the user clicks external link on a step, they lose the current page.

## Refs

- Fixes issue [#139](https://github.com/rsksmart/rsksmart.github.io/issues/139)
