### PR TITLE
feat: detect when being built by github pages for external links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,5 @@ group :jekyll_plugins do
   gem "jekyll-last-modified-at", "1.2.1"
   gem "jekyll-github-metadata", "2.12.1"
   gem "jemoji", "0.10.2"
-  gem "jekyll-target-blank", "2.0.0" if ENV["RAKE_BUILD_FOR"] == "prod"
+  gem "jekyll-target-blank", "2.0.0" if ENV["RAKE_BUILD_FOR"] == "prod" or ENV["GH_ENV"] == "gh_pages"
 end
-


### PR DESCRIPTION
## What

- detect when being built by github pages for external links

## Why

- Github Pages builds Jekyll using it's own method, doesn't allow customisations, so a Github Pages specific workaround is necessary

## Refs

- Fixes issue [#139](https://github.com/rsksmart/rsksmart.github.io/issues/139)
- Follow up for PR: [140](https://github.com/rsksmart/rsksmart.github.io/pull/140)
