### PR TITLE
fix: add missing tags and description

### DIFF
--- a/_rsk/architecture/2-way-peg.md
+++ b/_rsk/architecture/2-way-peg.md
@@ -2,6 +2,8 @@
 layout: rsk
 title: 2-way peg
 collection_order: 4300
+tags: rsk, rbtc, btc, peg
+description: "Transfer BTC to RBTC, and RBTC to BTC through a 2-way peg."
 ---
 
 The 2-Way Peg is a method to [transfer BTC into RBTC](/rsk/rbtc/conversion/), and vice-versa. In practice, when BTC and RBTC are exchanged, no currency is “transferred” between blockchains.

--- a/_rsk/architecture/account-based.md
+++ b/_rsk/architecture/account-based.md
@@ -2,6 +2,8 @@
 layout: rsk
 title: Account Based RSK Addresses
 collection_order: 4200
+tags: rsk, checksum, chainId, address
+description: "EIP1191 chainId is used in RSK addresses as a checksum"
 ---
 
 RSK Addresses incorporate an optional blockchain identifier (also known as `chainId`). If the `chainId` is not present, it is assumed the address refers to the RSK main network.

--- a/_rsk/architecture/fast-payments.md
+++ b/_rsk/architecture/fast-payments.md
@@ -2,14 +2,16 @@
 layout: rsk
 title: Fast payments
 collection_order: 4700
+tags: rsk, remasc, interval, speed, propagation
+description: "Achieving faster on-chain block intervals"
 ---
 
-RSK already enables second layer off-chain payment networks, but still RSK aims to provide a much better on-chain payment network compared to Bitcoin. To achieve this, RSK adopts the [REMASC protocol](/rsk/architecture/mining/remasc/), which allows RSK to reach a fifteen second average block rate, without creating incentives for mining centralization and selfish mining.
+RSK already enables second layer off-chain payment networks, but RSK still aims to provide a much better on-chain payment network compared to Bitcoin. To achieve this, RSK adopts the [REMASC protocol](/rsk/architecture/mining/remasc/), which allows RSK to reach a fifteen second average block rate, without creating incentives for mining centralization and selfish mining.
 
 Main features:
 
 * Fifteen to thirty second block intervals, depending on the miner’s state switching efficiency
-* Full network propagation of last competing blocks to prevent selfish mining and  reduce stale block rate
+* Full network propagation of last competing blocks to prevent selfish mining and reduce stale block rate
   * [RSK White Paper Overview](https://www.rsk.co/Whitepapers/RSK-White-Paper-Updated.pdf), see page 17
 * New network command to spread block headers with time critical priority
 * [REMASC protocol](/rsk/architecture/mining/remasc/) for reward sharing between competing blocks

--- a/_rsk/architecture/privacy.md
+++ b/_rsk/architecture/privacy.md
@@ -2,8 +2,8 @@
 layout: rsk
 title: Transaction Privacy
 collection_order: 4600
+tags: rsk, privacy, anonymous, pseudonymous
+description: "Transaction pseudonymity vs transaction anonymity"
 ---
-
-## Transaction Privacy
 
 RSK does not inherently provide better transaction privacy than Bitcoin, and relies on pseudonymity. Nevertheless, the VM of RSK is [Turing-complete](/rsk/architecture/turing-complete/), and thus anonymization technologies such as CoinJoin, ring Signatures or zCash can be implemented securely without third-party trust.

--- a/_rsk/architecture/security.md
+++ b/_rsk/architecture/security.md
@@ -2,6 +2,8 @@
 layout: rsk
 title: Security model
 collection_order: 4500
+tags: rsk, security, peg, federation
+description: "Achieving security in a 2-way pegged sidechain using proofs of payment"
 ---
 
 A sidechain is an independent blockchain whose native currency is pegged to the value of another blockchain currency automatically by using proofs of payment. There is a [2-way peg](/rsk/architecture/2-way-peg/) when two currencies can be exchanged freely, automatically, and without incurring in a price negotiation. In RSK, the Smart Bitcoin (RBTC) is two-way pegged to the BTC.

--- a/_rsk/architecture/turing-complete.md
+++ b/_rsk/architecture/turing-complete.md
@@ -2,11 +2,13 @@
 layout: rsk
 title: Turing complete
 collection_order: 4100
+tags: rsk, rvm, evm, virtual machine
+description: "The RSK virtual machine is compatible with Ethereum Virtual machine at an opcode level."
 ---
 
-## Turing-Complete
+RSK virtual machine (RVM) is the core of the Smart Contract platform. Smart Contracts are executed by all network full nodes. The result of the execution of a Smart Contract can be the processing of inter-contract messages, creating monetary transactions and changing the state of contract-persistent memory. The RVM is compatible with EVM at the op-code level, allowing Ethereum contracts to run flawlessly on RSK.
 
-RSK virtual machine (RVM) is the core of the Smart Contract platform. Smart Contracts are executed by all network full nodes. The result of the execution of a Smart Contract can be the processing of inter-contract messages, creating monetary transactions and changing the state of contract-persistent memory. The RVM is compatible with EVM at the op-code level, allowing Ethereum contracts to run flawlessly on RSK. Currently, the VM is executed by interpretation. In a future network upgrade, the RSK community is aiming to improve the VM performance substantially. One proposal is to emulate the EVM by dynamically retargeting EVM opcodes to a subset of Java-like bytecode, and a security-hardened and memory restricted Java-like VM will become the new VM (RVM2). This may bring RSK code execution to a performance close to native code.
+Currently, the VM is executed by interpretation. In a future network upgrade, the RSK community is aiming to improve the VM performance substantially. One proposal is to emulate the EVM by dynamically retargeting EVM opcodes to a subset of Java-like bytecode, and a security-hardened and memory restricted Java-like VM will become the new VM (RVM2). This may bring RSK code execution to a performance close to native code.
 
 Main features:
 


### PR DESCRIPTION
## What

- Add `tags` and `description` to pages in `/rsk/architecture/*`

## Why

- Improve searchability

