### PR TITLE
feat: convert table to headings in order to enable direct anchor links.

### DIFF
--- a/rif/rns/libs/javascript/Errors.md
+++ b/rif/rns/libs/javascript/Errors.md
@@ -4,19 +4,86 @@ title: RNS JS Library - Error knowledge base
 tags: rns, javascript
 ---
 
-|Code | Message | Description |
-|--- | --- | ---|
-|KB001|No addr resolution set|The given domain has a resolver, but the resolution has not been set|
-|KB002|No addr resolution|The given domain has a resolver, but it does not support [addr](/rif/rns/architecture/Resolver/#addr) interface|
-|KB003|No resolver|The given domain doesn't have a resolver set|
-|KB004|Library not composed|Thrown when trying to accesses `rns.contracts` before executing `rns.compose()`|
-|KB005|No contract addresses provided|Thrown when constructing lib on a local/custom RNS environment and contract addresses are not provided|
-|KB006|No chain address resolution|The given domain has a resolver, but the resolution for the given chain has not been set|
-|KB007|No chain address resolution set|The given domain has a resolver, but it does not support [chainAddr](/rif/rns/architecture/MultiCryptoResolver) interface|
-|KB008|Search only domains|-|
-|KB009|Search only `.rsk` domains|-|
-|KB010|Invalid domain, must be alphanumeric and lower case|-|
-|KB011|Invalid label, must be alphanumeric and lower case|-|
-|KB012|The given domain does not exist|-|
-|KB013|No name resolution|The given address has a reverse resolver, but it does not support [name](/rif/rns/architecture/NameResolver#name) interface|
-|KB014|No reverse resolution set|The given address has not the reverse resolution set|
+## `KB001`
+
+**Message**: No addr resolution set
+
+**Description**: The given domain has a resolver, but the resolution has not been set
+
+## `KB002`
+
+**Message**: No addr resolution
+
+**Description**: The given domain has a resolver, but it does not support [addr](/rif/rns/architecture/Resolver/#addr) interface
+
+## `KB003`
+
+**Message**: No resolver
+
+**Description**: The given domain doesn't have a resolver set
+
+## `KB004`
+
+**Message**: Library not composed
+
+**Description**: Thrown when trying to accesses `rns.contracts` before executing `rns.compose()`
+
+## `KB005`
+
+**Message**: No contract addresses provided
+
+**Description**: Thrown when constructing lib on a local/custom RNS environment and contract addresses are not provided
+
+## `KB006`
+
+**Message**: No chain address resolution
+
+**Description**: The given domain has a resolver, but the resolution for the given chain has not been set
+
+## `KB007`
+
+**Message**: No chain address resolution set
+
+**Description**: The given domain has a resolver, but it does not support [chainAddr](/rif/rns/architecture/MultiCryptoResolver) interface
+
+## `KB008`
+
+**Message**: Search only domains
+
+**Description**: -
+
+## `KB009`
+
+**Message**: Search only `.rsk` domains
+
+**Description**: -
+
+## `KB010`
+
+**Message**: Invalid domain, must be alphanumeric and lower case
+
+**Description**: -
+
+## `KB011`
+
+**Message**: Invalid label, must be alphanumeric and lower case
+
+**Description**: -
+
+## `KB012`
+
+**Message**: The given domain does not exist
+
+**Description**: -
+
+## `KB013`
+
+**Message**: No name resolution
+
+**Description**: The given address has a reverse resolver, but it does not support [name](/rif/rns/architecture/NameResolver#name) interface
+
+## `KB014`
+
+**Message**: No reverse resolution set
+
+**Description**: The given address has not the reverse resolution set


### PR DESCRIPTION
## What

- Errors were previously listed in a table, but now each one has its own heading

## Why

- The RNS Javascript lib would like to have custom error messages that link directly to the error message in question
  - e.g. `KB012` maps to `https://developers.rsk.co/rif/rns/libs/javascript/Errors/#kb012`

## Refs

- Issue: https://github.com/rnsdomains/rns-js/issues/32
- Fixes: https://github.com/rsksmart/rsksmart.github.io/issues/157
- Ticket: https://trello.com/c/RFkuT7ow/205
