### PR TITLE
feat: render math equations

### DIFF
--- a/_layouts/rsk.html
+++ b/_layouts/rsk.html
@@ -82,6 +82,11 @@
       <script src="/assets/vendor/jquery/jquery.min.js"></script>
       <script src="/assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
       <script src="/assets/js/main.js"></script>
+      {% if page.render_equations %}
+         <!-- katex for rendering math equations -->
+         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
+         <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous" onload="renderEquations();"></script>
+      {% endif %}
       <script src="/assets/vendor/carousel/owl.carousel.min.js"></script>
       <script type="text/javascript">
       $('.owl-carousel').owlCarousel({

--- a/_rsk/architecture/mining/remasc.md
+++ b/_rsk/architecture/mining/remasc.md
@@ -3,6 +3,7 @@ layout: rsk
 title: REMASC
 tags: rsk, mining, bitcoin, remasc
 collection_order: 4430
+render_equations: true
 ---
 
 Reward Manager Smart Contract (REMASC) is a pre-compiled smart-contract that is executed on every block and has the responsibility to fairly distribute rewards collected from transaction fees into several participants of the network. However the distribution of rewards of a block is only performed once the block reaches a certain maturity. In other words, the rewards are paid only after a  fixed number of blocks have confirmed a block. With the exception of the first blocks in the blockchain after genesis, every time a block is added to the blockchain, another previous block reaches maturity and its rewards are paid.
@@ -31,19 +32,24 @@ One and only one block is mined at a height **N**. This block is the **main bloc
 
 The payment for the miners of the main block, the siblings and the publishers will occur on the block N + 4000. The payment occurs as specified by the following rules:
 
-* <img src="https://latex.codecogs.com/svg.latex?$\textit{FullBlock_{rwd}}$"/> *is the 100% of the block reward*
+* [](#top "tex-render FullBlock_{rwd}") *is the 100% of the block reward*
 * RSK will receive a fee of ~20% of the full block reward:
-  <img src="https://latex.codecogs.com/svg.latex?Rsk_{rwd}=\frac{FullBlock_{rwd}}{5}"/>
+
+  [](#top "tex-render Rsk_{rwd}=\frac{FullBlock_{rwd}}{5}")
+
 * RSK Federation will receive a fee of ~0.8% of the full block reward:
-  <img src="https://latex.codecogs.com/svg.latex?Fed_{rwd}=\frac{FullBlock_{rwd}-Rsk_{rwd}}{100}"/>
+
+  [](#top "tex-render Fed_{rwd}=\frac{FullBlock_{rwd}-Rsk_{rwd}}{100}")
+
 * Miners will receive a payment of ~79.2% of the full block reward:
-  <img src="https://latex.codecogs.com/svg.latex?Miners_{rwd}=FullBlock_{rwd}-Rsk_{rwd}-Fed_{rwd}"/>
+
+  [](#top "tex-render Miners_{rwd}=FullBlock_{rwd}-Rsk_{rwd}-Fed_{rwd}")
 
 <br/>
 
 *It’s important to notice that these are integer divisions where results are rounded down. That’s why:*
 
-<img src="https://latex.codecogs.com/svg.latex?\frac{\textit{4}}{\textit{5}}*FullBlock_{rwd}%20\neq%20FullBlock_{rwd}-\frac{FullBlock_{rwd}}{5}"/>
+[](#top "tex-render \frac{4}{5}*FullBlock_{rwd} \neq FullBlock_{rwd}-\frac{FullBlock_{rwd}}{5}")
 
 <br/>
 
@@ -52,50 +58,62 @@ Now we present several different scenarios:
 1. There are **no** siblings at height N
     * **No Rule was broken**
     The miner of the block at height N is paid
-    <img src="https://latex.codecogs.com/svg.latex?Miners_{rwd}"/>
+    [](#top "tex-render Miners_{rwd}")
+
     * **Rule was broken**
     The miner is paid 90% of the
-    <img src="https://latex.codecogs.com/svg.latex?Miners_{rwd}"/>
+    [](#top "tex-render Miners_{rwd}")
+
     which is defined as
-    <img src="https://latex.codecogs.com/svg.latex?%20Miners_{rwdBroken}=Miners_{rwd}-\frac{Miners_{rwd}}{10}%20%22"/>
+    [](#top "tex-render  Miners_{rwdBroken}=Miners_{rwd}-\frac{Miners_{rwd}}{10} %22")
+
 2. There are siblings at height N.
    Each sibling will have a respective publisher and miner, so we define:
-   * **Publisher Fee** (~10% of
-     <img src="https://latex.codecogs.com/svg.latex?Miners_{rwd}"/>
-     )
-     <img src="https://latex.codecogs.com/svg.latex?PubFee_{rwd}=\frac{Miners_{rwd}}{10}"/>
-   * **Miner Fee** (~90% of
-     <img src="https://latex.codecogs.com/svg.latex?Miners_{rwd}"/>
-     )
-     <img src="https://latex.codecogs.com/svg.latex?MinersFee_{rwd}=Miners_{rwd}-PubFee_{rwd}"/>
+   * **Publisher Fee** (~10% of [](#top "tex-render Miners_{rwd}") )
+
+     [](#top "tex-render PubFee_{rwd}=\frac{Miners_{rwd}}{10}")
+
+   * **Miner Fee** (~90% of [](#top "tex-render Miners_{rwd}") )
+
+     [](#top "tex-render MinersFee_{rwd}=Miners_{rwd}-PubFee_{rwd}")
+
      If we S is the number of siblings, we define:
     * **Individual Publisher Fee**
-      <img src="https://latex.codecogs.com/svg.latex?IndPubFee_{rwd}=\frac{PubFee_{rwd}}{S}"/>
+
+      [](#top "tex-render IndPubFee_{rwd}=\frac{PubFee_{rwd}}{S}")
+
    * **Individual Mining Fee**
      To simplify we define
-     <img src="https://latex.codecogs.com/svg.latex?Mining_{rwd}=\frac{MiningFees_{rwd}}{S+1}"/>,
+
+     [](#top "tex-render Mining_{rwd}=\frac{MiningFees_{rwd}}{S+1}"),
+
      is given by the Mining Fee over all mined blocks referenced on the blockchain (which is siblings + the main block), then individual mining fee is:
      * No Rule was broken
-       <img src="https://latex.codecogs.com/svg.latex?IndMiningFee_{rwd}=Mining_{rwd}"/>
+
+       [](#top "tex-render IndMiningFee_{rwd}=Mining_{rwd}")
+
      * Rule was broken
-       <img src="https://latex.codecogs.com/svg.latex?IndMiningFee_{rwdBroken}=Mining_{rwd}-\frac{Mining_{rwd}}{10}-L"/>
+
+       [](#top "tex-render IndMiningFee_{rwdBroken}=Mining_{rwd}-\frac{Mining_{rwd}}{10}-L")
 
 Finally, with all the previous variables computed, the payments will be performed as follows:
 
 Each **publisher** receives
-<img src="https://latex.codecogs.com/svg.latex?PubFee_{rwd}"/>
-The **miner of the main block** receives
-<img src="https://latex.codecogs.com/svg.latex?IndMiningFee_{rwd}"/>
-Also, for **each sibling**, a new amount needs to be calculated. This is, for each late block that the sibling published, it receives a punishment of ~5% of the
-<img src="https://latex.codecogs.com/svg.latex?IndMiningFee{rwd}"/>.
-The sibling is added on the block N+D for some positive value of D. A punishment for late publication is calculated for each as
-<img src="https://latex.codecogs.com/svg.latex?L=%20\frac{(D-1)%20*%20IndMiningFee_{Rwd}}{20}"/>
-Then the respective miners are paid
-<img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}=%20IndMiningFee_{Rwd}%20-%20L"/>
+[](#top "tex-render PubFee_{rwd}")
 
-The remaining amount of
-<img src="https://latex.codecogs.com/svg.latex?Miners_{rwd}"/>
-is added to a balance called **Burned Balance**. As of this writing, burned money is lost but changes may apply. The Burned Balance is given by rounding errors or punishments.
+The **miner of the main block** receives
+[](#top "tex-render IndMiningFee_{rwd}")
+
+Also, for **each sibling**, a new amount needs to be calculated. This is, for each late block that the sibling published, it receives a punishment of ~5% of the
+[](#top "tex-render IndMiningFee_{rwd}").
+
+The sibling is added on the block N+D for some positive value of D. A punishment for late publication is calculated for each as
+[](#top "tex-render L= \frac{(D-1) * IndMiningFee_{Rwd}}{20}")
+
+Then the respective miners are paid
+[](#top "tex-render IndMiningFeeLate_{rwd}= IndMiningFee_{Rwd} - L")
+
+The remaining amount of [](#top "tex-render Miners_{rwd}") is added to a balance called **Burned Balance**. As of this writing, burned money is lost but changes may apply. The Burned Balance is given by rounding errors or punishments.
 
 ## Example
 
@@ -108,27 +126,40 @@ A, B and C share the parent P. B is the main block at height N and A and C are s
 This way, we compute:
 
 * **RSK** receives
-  <img src="https://latex.codecogs.com/svg.latex?Rsk_{rwd}=%20\frac{FullBlock_{rwd}}{5}%20\implies%20\frac{10000}{5}%20\implies%20Rsk_{rwd}%20=%202000"/>
-* **RSK Federation** receives
-  <img src="https://latex.codecogs.com/svg.latex?Fed_{rwd}=%20\frac{FullBlock_{rwd}-Rsk_{rwd}}{100}%20\implies%20\frac{10000-2000}{100}%20\implies%20Fed_{rwd}%20=%2080"/>
-* **Miners** receive a total of
-  <img src="https://latex.codecogs.com/svg.latex?MinerFee_{rwd}=%20Miner_{rwd}-PubFee_{rwd}%20\implies%207920-792%20\implies%20MinerFee_{rwd}%20=%207128"/>
-    * **B** and **C** blocks receive Individual Mining Fee
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFee_{rwd}=%20\frac{MinerFee_{rwd}}{S+1}%20\implies%20\frac{7128}{3}%20\implies%20IndMiningFee_{rwd}%20=%202376"/>
-      *In this case blocks are not published late so L is 0, that is why*
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFee_{rwd}"/>
-      *is used in the calculation instead of*
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}"/>
-    * **A** receives
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}=IndMiningFee_{rwd}%20-%20L"/>
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}=IndMiningFee_{rwd}%20-%20\frac{(D-1)%20*%20IndMiningFee_{Rwd}}{20}"/>
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}=%202376%20=%20IndMiningFee_{rwd}%20-%20\frac{(2-1)%20*%202376}{20}"/>
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}=%202257"/>
-      *In this case A was published late so L is not 0, that is why*
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwd}"/> *is used in the calculation instead of*
-      <img src="https://latex.codecogs.com/svg.latex?IndMiningFee_{rwd}"/>
 
-For this example, an assumption that there wasn’t a broken rule for any block was made. Otherwise, fees paid should have been calculated using <img src="https://latex.codecogs.com/svg.latex?IndMiningFeeLate_{rwdBroken}"/>.
+  [](#top "tex-render Rsk_{rwd}= \frac{FullBlock_{rwd}}{5} \implies \frac{10000}{5} \implies Rsk_{rwd} = 2000")
+
+* **RSK Federation** receives
+
+  [](#top "tex-render Fed_{rwd}= \frac{FullBlock_{rwd}-Rsk_{rwd}}{100} \implies \frac{10000-2000}{100} \implies Fed_{rwd} = 80")
+
+* **Miners** receive a total of
+  [](#top "tex-render MinerFee_{rwd}= Miner_{rwd}-PubFee_{rwd} \implies 7920-792 \implies MinerFee_{rwd} = 7128")
+    * **B** and **C** blocks receive Individual Mining Fee
+
+      [](#top "tex-render IndMiningFee_{rwd}= \frac{MinerFee_{rwd}}{S+1} \implies \frac{7128}{3} \implies IndMiningFee_{rwd} = 2376")
+
+      *In this case blocks are not published late so L is 0, that is why*
+      [](#top "tex-render IndMiningFee_{rwd}")
+      *is used in the calculation instead of*
+      [](#top "tex-render IndMiningFeeLate_{rwd}")
+
+    * **A** receives
+
+      [](#top "tex-render IndMiningFeeLate_{rwd}=IndMiningFee_{rwd} - L")
+
+      [](#top "tex-render IndMiningFeeLate_{rwd}=IndMiningFee_{rwd} - \frac{(D-1) * IndMiningFee_{Rwd}}{20}")
+
+      [](#top "tex-render IndMiningFeeLate_{rwd}= 2376 = IndMiningFee_{rwd} - \frac{(2-1) * 2376}{20}")
+
+      [](#top "tex-render IndMiningFeeLate_{rwd}= 2257")
+
+      *In this case A was published late so L is not 0, that is why*
+      [](#top "tex-render IndMiningFeeLate_{rwd}")
+      *is used in the calculation instead of*
+      [](#top "tex-render IndMiningFee_{rwd}")
+
+For this example, an assumption that there wasn’t a broken rule for any block was made. Otherwise, fees paid should have been calculated using [](#top "tex-render IndMiningFeeLate_{rwdBroken}").
 
 ## References
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,10 +1,10 @@
-// store dark /light theme 
+// store dark /light theme
 
 $(document).ready(function(){
     // Check local storage and set theme
     if(localStorage.theme) {
         $('html').addClass( localStorage.theme );
-    } 
+    }
     else{
         $('html').addClass('light'); // set default theme. No need to set via php now
     }
@@ -12,8 +12,8 @@ $(document).ready(function(){
   if ($('html').hasClass('dark')) {
   $('#logo').attr('src','/assets/img/rsk_logo_reverse.svg');
   $('#theme-toggler').text('Light');
-} 
-else  { 
+}
+else  {
    $('#logo').attr('src','/assets/img/rsk_logo.svg');
    $('#theme-toggler').text('Dark');
  }
@@ -241,4 +241,22 @@ function setUpMainSearch () {
       // do nothing
     }
   });
+}
+
+function renderEquations() {
+  console.log('renderEquations');
+  var elemNodeList = document.querySelectorAll('a[title^="tex-render "]');
+  var elems = Array.prototype.slice.call(elemNodeList);
+  elems.forEach(renderEquation);
+}
+
+function renderEquation(el) {
+  var equation = el.getAttribute('title').slice('tex-render '.length);
+  var equationEl = document.createElement('span');
+  katex.render(equation, equationEl, {
+    throwOnError: false,
+  });
+  equationEl.setAttribute('title', equation);
+  equationEl.classList.add('tex-rendered');
+  el.replaceWith(equationEl);
 }


### PR DESCRIPTION
## What

- Add dependency on [katex](https://katex.org/docs/api.html) for rendering the equations
  - Load katex only on pages that have `render_equations: true` in their front matter, since it is expected to be needed only in a minority of pages
- Modify the `/rsk/architecture/mining/remasc/` page
  - to render equations using client-side
  - remove references to latex.codecogs.org

## Why

- Cannot rely on external service for rendering, as they can introduce regressions, and has done so in the case of latex.codecogs.org

## Refs

- Fixes issue [#186](https://github.com/rsksmart/rsksmart.github.io/issues/186)
- [Task](https://trello.com/c/BGmZWyOM/221)
