### PR TITLE
fix: delete cyclical link

### DIFF
--- a/_rsk/node/contribute/index.md
+++ b/_rsk/node/contribute/index.md
@@ -20,5 +20,4 @@ Compile and run your own node, step by step:
 After the previous steps have been completed, you can try these tutorials:
 
 - [From one node to a mining local network](/rsk/node/configure/for-mining)
-- [Monitor the blockchain](https://github.com/rsksmart/rskj/wiki/Monitor-the-blockchain)
 - [Smart contracts and queries over the blockchain](/tutorials)


### PR DESCRIPTION
## What

- Delete the link

## Why

- Cyclical link between https://github.com/rsksmart/rskj/wiki/Monitor-the-blockchain and https://developers.rsk.co/rsk/node/contribute/
- Page is no longer relevant

## Refs

- Fixes issue: [#184](https://github.com/rsksmart/rsksmart.github.io/issues/184)
- [Task](https://trello.com/c/Wo6OVpn3/229)
