### PR TITLE
feat: fallback for date and time rendering

### DIFF
--- a/webinars/js/main.js
+++ b/webinars/js/main.js
@@ -116,27 +116,37 @@ function renderLocalTimes() {
 }
 
 function renderLocalTime(el, timestamp) {
-  var dateStr = new Date(timestamp).toLocaleDateString(
-    undefined,
-    {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    },
-  );
+  var timeStampDate = new Date(timestamp);
 
-  var timeStr = new Date(timestamp).toLocaleDateString(
-    undefined,
-    {
-      hour: 'numeric',
-      minute: 'numeric',
-    },
-  );
-
-  var fullDateString = (new Date(timestamp)).toString();
+  var fullDateString = (timeStampDate).toString();
   var tzSplitIndex = nthCharacter(fullDateString, ' ', 5);
   var tzStr = fullDateString.substring(tzSplitIndex + 1);
+
+  var dateStr;
+  var timeStr;
+  if (typeof timeStampDate.toLocaleTimeString === 'function') {
+    dateStr = timeStampDate.toLocaleDateString(
+      undefined,
+      {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      },
+    );
+
+    timeStr = timeStampDate.toLocaleTimeString(
+      undefined,
+      {
+        hour: 'numeric',
+        minute: 'numeric',
+      },
+    );
+  } else {
+    var timeSplitIndex = nthCharacter(fullDateString, ' ', 4);
+    dateStr = fullDateString.substring(0, timeSplitIndex);
+    timeStr = fullDateString.substring(timeSplitIndex + 1, tzSplitIndex);
+  }
 
   var dateEl = $(el).find('.display-date');
   var timeEl = $(el).find('.display-time');

--- a/webinars/js/main.js
+++ b/webinars/js/main.js
@@ -105,8 +105,9 @@ function concatValues( obj ) {
   renderLocalTimes();
 });
 
+// Iterate over all "event" elements and attempt to render their times
+// where the timestamp property is present
 function renderLocalTimes() {
-  console.log('renderLocalTimes');
   $('.eventos').each(function () {
     var timestamp = $(this).data('timestamp');
     if (timestamp) {
@@ -115,9 +116,13 @@ function renderLocalTimes() {
   });
 }
 
+// For a particular "event" element, update its DOM in specific places
+// to display the date, time, and time zone specific to the user' locale.
+// In older browsers, use a best-effort approach for date-time localisation.
 function renderLocalTime(el, timestamp) {
   var timeStampDate = new Date(timestamp);
 
+  // extract full timezone details from Date, for user's locale
   var fullDateString = (timeStampDate).toString();
   var tzSplitIndex = nthCharacter(fullDateString, ' ', 5);
   var tzStr = fullDateString.substring(tzSplitIndex + 1);
@@ -125,6 +130,7 @@ function renderLocalTime(el, timestamp) {
   var dateStr;
   var timeStr;
   if (typeof timeStampDate.toLocaleTimeString === 'function') {
+    // for modern browsers, extract locale specific date and time strings
     dateStr = timeStampDate.toLocaleDateString(
       undefined,
       {
@@ -143,6 +149,8 @@ function renderLocalTime(el, timestamp) {
       },
     );
   } else {
+    // for older browsers, fall back on `Date.prototype.toString` to extract
+    // non-locale specific date and time strings
     var timeSplitIndex = nthCharacter(fullDateString, ' ', 4);
     dateStr = fullDateString.substring(0, timeSplitIndex);
     timeStr = fullDateString.substring(timeSplitIndex + 1, tzSplitIndex);
@@ -156,9 +164,11 @@ function renderLocalTime(el, timestamp) {
   tzEl.text(tzStr);
 }
 
+// Returns the index of the `n`th occurrence of `character` within `string`
 function nthCharacter(string, character, n) {
   var count = 0;
   var i = 0;
+  // repeatedly call `String.prototype.indexOf` until the nth count has been reached
   while (count < n && (i = string.indexOf(character, i) + 1)) {
     ++count;
   }


### PR DESCRIPTION
## What

- Fall back for parsing date and time using `Date.prototype.toString()`
- Make time <span> only display the time

## Why

- The time <span> was displaying date and time for older browsers that don't support
  `Date.prototype.toLocaleDateString`
- Don't display redundant info

## Refs

- Related PRs: [#198](https://github.com/rsksmart/rsksmart.github.io/pull/198)
- [Task](https://trello.com/c/qzTQj7Mq/238)
