### PR TITLE
proj: exclude node modules folder in jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ exclude:
   - .bundle
   - vendor
   - assets/img/windowsInstall/
+  - node_modules
 
 plugins:
  - jekyll-last-modified-at


### PR DESCRIPTION
## What

- configure jekyll to exclude `node_modules` dir in build

## Why

- able to run `rake test` in local development env without seeing these errors
  - note: does not affect actual build, because this is not checked out or installed in CI
