### PR TITLE
fix: URLs in menu

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -238,7 +238,7 @@
                   <li><a href="/rif/rns/tools/Web3/">Web3</a></li>
                   <li><a href="/rif/rns/tools/MyCrypto/">MyCrypto</a></li>
                   <li><a href="/rif/rns/tools/RNS-Manager/">RNS Manager</a></li>
-                  <li><a href="/rif/rns/tools/Subdomain-tool">Subdomain tool</a></li>
+                  <li><a href="/rif/rns/tools/Subdomain-tool/">Subdomain tool</a></li>
                 </ul>
               </li>
               <li>
@@ -270,7 +270,7 @@
                 <a href="/rif/rns/integrate/">Integrate</a>
                 <ul>
                   <li class="hide-mobile"><a href="/rif/rns/integrate/">Integrate</a></li>
-                  <li><a href="/rif/rns/integrate/integrate-addr-resolution">Quick start</a></li>
+                  <li><a href="/rif/rns/integrate/integrate-addr-resolution/">Quick start</a></li>
                   <li><a href="/rif/rns/integrate/integrate-dapp/">Integrate your dApp</a></li>
                   <li><a href="/rif/rns/integrate/integrate-wallet/">Integrate your wallet</a></li>
                 </ul>
@@ -459,11 +459,11 @@
                 <ul>
                   <li class="hide-mobile"><a href="/develop/apps/wallets/">Wallets</a></li>
                   <li><a href="/develop/apps/wallets/ledger/">Ledger</a></li>
-                  <li><a href="/develop/apps/wallets/nifty">Nifty</a></li>
-                  <!--li><a href="/develop/apps/wallets/portis">Portis</a></li-->
+                  <li><a href="/develop/apps/wallets/nifty/">Nifty</a></li>
+                  <!--li><a href="/develop/apps/wallets/portis/">Portis</a></li-->
                   <li><a href="/develop/apps/wallets/jaxx/">Jaxx</a></li>
                   <li><a href="/develop/apps/wallets/mycrypto/">MyCrypto</a></li>
-                  <!--li><a href="/develop/apps/wallets/myetherwallet">MyEtherWallet</a></li-->
+                  <!--li><a href="/develop/apps/wallets/myetherwallet/">MyEtherWallet</a></li-->
                   <li><a href="/develop/apps/wallets/metamask/">MetaMask</a></li>
                   <li><a href="/develop/apps/wallets/json-rpc/">JSON-RPC</a></li>
                 </ul>
@@ -471,7 +471,7 @@
               <!--li>
                 <a href="/develop/apps/identity/">Identity</a>
                 <ul>
-                  <li><a href="/develop/apps/identity/uport">uPort</a></li>
+                  <li><a href="/develop/apps/identity/uport/">uPort</a></li>
                 </ul>
                 </li-->
             </ul>


### PR DESCRIPTION
URLs in menu must have the slash char "/" in the end.

## What

- Adding slash char in all menu items

## Why

- URLs are routed to the ending dash resource, menu must respect that rule
- The breadcrumbs are built using the navigation menu