### PR TITLE
Docs: Added commands to exit REPL

### DIFF
--- a/_quick-start/step2-install-truffle-and-ganache.md
+++ b/_quick-start/step2-install-truffle-and-ganache.md
@@ -84,16 +84,10 @@ web3.eth.net.getId()
 
 Ensure that the output is `33`, which is the network ID of the regtest node.
 
-Enter the command below to exit the REPL on Windows.
+Enter the command below to exit the REPL.
 
 ```shell
-CTRL-Z
-```
-
-Enter the command below to exit the REPL on Mac.
-
-```shell
-CTRL-C
+.exit
 ```
 
 ### Install Ganache

--- a/_quick-start/step2-install-truffle-and-ganache.md
+++ b/_quick-start/step2-install-truffle-and-ganache.md
@@ -78,11 +78,23 @@ and look for the options related to that within the `truffle-config.js` file.
 We can verify this by entering the following command:
 
 ```javascript
-truffle(regtest)>  web3.eth.net.getId()
+web3.eth.net.getId()
 33
 ```
 
-Esnure that the output is `33`, which is the network ID of the regtest node.
+Ensure that the output is `33`, which is the network ID of the regtest node.
+
+Enter the command below to exit the REPL on Windows.
+
+```shell
+CTRL-Z
+```
+
+Enter the command below to exit the REPL on Mac.
+
+```shell
+CTRL-C
+```
 
 ### Install Ganache
 


### PR DESCRIPTION
## What

- Added commands to exit REPL for Mac and Windows Users

## Why
- There was no command on how to exit the REPL after getting the network id in the regtest node

## Refs

- [Doc Link](https://developers.rsk.co/quick-start/step2-install-truffle-and-ganache/)
