### PR TITLE
fix: update events 20200425s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ yarn.lock
 /node_modules
 /package-lock.json
 /Gemfile.lock
-Gemfile.lock

--- a/tutorials/frontend/first-frontend-web3-injected.md
+++ b/tutorials/frontend/first-frontend-web3-injected.md
@@ -28,7 +28,10 @@ Steps 1 to 4 are explained in detail in the tutorial link below:
 
 ## Webinar
 
-We have run a webinar in which we run through this tutorial:
+
+We have run a
+[webinar](/webinars/#event-id-202004-027 "Create your first frontend for a Smart Contract on RSK")
+in which we run through this tutorial:
 
 <div class="video-container">
   <iframe width="949" height="534" src="https://www.youtube-nocookie.com/embed/CoO9k1LYO04?cc_load_policy=1" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/webinars/index.html
+++ b/webinars/index.html
@@ -355,7 +355,7 @@
                   <div class="row">
                {% for event in events %}
                   {% capture timestamp %}{{ event.timestamp | date: '%s' | plus: 0 %}}{% endcapture %}
-                  {% if timestamp <= now and event.recordedVideoUrl != "" %}
+                  {% if timestamp <= now %}
                   <!-- Past event -->
 
                   <div
@@ -378,11 +378,17 @@
                               <span>
                                  <i class="fa fa-video" aria-hidden="true"></i>
                                  <span class="text display-recorded-video-url">
+                                    {% if event.recordedVideoUrl != "" %}
                                     <a href="{{ event.recordedVideoUrl }}"
                                        rel="noreferrer noopener"
                                        target="_blank">
                                        View Recording
                                     </a>
+                                    {% else %}
+                                    <span>
+                                       Recording not available
+                                    </span>
+                                    {% endif %}
                                  </span>
                               </span>
                               <span>


### PR DESCRIPTION
## What

- Render all past events, not just those with recorded videos

## Why

- So that we may have permalinks immediately after an event is completed, before its video is uploaded

## Refs

- Related PRs: [#274](https://github.com/rsksmart/rsksmart.github.io/pull/274)
