### PR TITLE
[Docs] Updated new truffle-oz, and pet-shop-box tutorials links by Solange Gueiros

### DIFF
--- a/tools/truffle/boxes.md
+++ b/tools/truffle/boxes.md
@@ -13,4 +13,4 @@ RSK has its own specialized Truffle Boxes:
 - [rsk-react-box](/tutorials/truffle-boxes/rsk-react-box): This box comes with everything you need to start using smart contracts from a react app on RSK Network. 
 - [rsk-next-box](/tutorials/truffle-boxes/rsk-next-box): In this box you'll find a basic starter pack. It includes Truffle and Next JS.
 - [rsk-react-express-box](/tutorials/truffle-boxes/rsk-react-express-box): In this box you'll find a basic starter pack. It includes Truffle, React and Express JS.
-- [rsk-pet-shop-box](/tutorials/truffle-boxes/pet-shop-box/): In this box, you will find all the guide needed to deploy smart contracts to multiple networks (Regtest and Testnet).
+- [rsk-pet-shop-box](/tutorials/truffle-boxes/pet-shop-box/):This tutorial is a guide on how to use a Truffle box, and on how to to deploy smart contracts to multiple networks (Regtest and Testnet).

--- a/tools/truffle/boxes.md
+++ b/tools/truffle/boxes.md
@@ -13,3 +13,4 @@ RSK has its own specialized Truffle Boxes:
 - [rsk-react-box](/tutorials/truffle-boxes/rsk-react-box): This box comes with everything you need to start using smart contracts from a react app on RSK Network. 
 - [rsk-next-box](/tutorials/truffle-boxes/rsk-next-box): In this box you'll find a basic starter pack. It includes Truffle and Next JS.
 - [rsk-react-express-box](/tutorials/truffle-boxes/rsk-react-express-box): In this box you'll find a basic starter pack. It includes Truffle, React and Express JS.
+- [rsk-pet-shop-box](/tutorials/truffle-boxes/pet-shop-box/): In this box, you will find all the guide needed to deploy smart contracts to multiple networks (Regtest and Testnet).

--- a/tools/truffle/index.md
+++ b/tools/truffle/index.md
@@ -23,6 +23,7 @@ npm install truffle -g
 ```
 
 ## More info:
+- [Truffle Open Zeppelin](/tutorials/ethereum-devs/setup-truffle-oz)
 - [Truffle Boxes](/tools/truffle/boxes)
 - [Truffle Ganache](/tools/truffle/ganache)
 - [Truffle Documentation](https://www.trufflesuite.com/docs)

--- a/tools/truffle/index.md
+++ b/tools/truffle/index.md
@@ -23,7 +23,8 @@ npm install truffle -g
 ```
 
 ## More info:
-- [Truffle Open Zeppelin](/tutorials/ethereum-devs/setup-truffle-oz)
+
+- [Truffle and Open Zeppelin](/tutorials/ethereum-devs/setup-truffle-oz)
 - [Truffle Boxes](/tools/truffle/boxes)
 - [Truffle Ganache](/tools/truffle/ganache)
 - [Truffle Documentation](https://www.trufflesuite.com/docs)


### PR DESCRIPTION
## What

- Updated new truffle tutorial link in tools/truffle in more info section
- Added pet-shop-box tutorial link in tools/truffle/boxes

## Why

- The truffle setup with open zeppelin tutorial needed to be included in the [more info section](https://developers.rsk.co/tools/truffle/)
- Added pet-shop-box tutorial links in the [truffle boxes section](https://developers.rsk.co/tools/truffle/boxes/)