### PR TITLE
docs: update block explorer URLs to remove trailing slash

### DIFF
--- a/develop/apps/wallets/metamask.md
+++ b/develop/apps/wallets/metamask.md
@@ -46,8 +46,8 @@ For MetaMask installation, please <a href="https://metamask.io/" target="_blank"
     </tr>
     <tr>
       <td>Block explorer URL</td>
-      <td><a href="https://explorer.rsk.co/" target="_blank">https://explorer.rsk.co/</a></td>
-      <td><a href="https://explorer.testnet.rsk.co/" target="_blank">https://explorer.testnet.rsk.co/</a></td>
+      <td><a href="https://explorer.rsk.co" target="_blank">https://explorer.rsk.co</a></td>
+      <td><a href="https://explorer.testnet.rsk.co" target="_blank">https://explorer.testnet.rsk.co</a></td>
     </tr>
   </tbody>
   </table>

--- a/tutorials/ethereum-devs/remix-and-metamask-with-rsk-testnet.md
+++ b/tutorials/ethereum-devs/remix-and-metamask-with-rsk-testnet.md
@@ -79,23 +79,19 @@ Can be accessed at [remix.ethereum.org](https://remix.ethereum.org/)
 
 - Network Name
 
-    RSK Testnet
-
+  `RSK Testnet`
 - New RPC URL
 
-    [https://public-node.testnet.rsk.co](https://public-node.testnet.rsk.co)
-
+  [`https://public-node.testnet.rsk.co`](https://public-node.testnet.rsk.co)
 - ChainID (optional)
 
-    31
-
+  `31`
 - Symbol (optional)
 
-    tR-BTC
-
+  `tR-BTC`
 - Block Explorer URL (optional)
 
-    https://explorer.testnet.rsk.co/
+  [`https://explorer.testnet.rsk.co`](https://explorer.testnet.rsk.co)
 
 
 ![RSK Testnet configuration](/assets/img/tutorials/remix-and-metamask-with-rsk-testnet/image-02.png)


### PR DESCRIPTION
## What

- update the general metamask config page as well as a specific tutorial to remove the trailing slash

## Why

- MetaMask generates a URL with a double-slash
  - e.g. `https://explorer.testnet.rsk.co//tx/0xc080215f5e43c21f174e20c698a14cbabf49d4f9a4f6c5a7d5f04b647e6e37e6`
  - This currently renders a blank page in the block explorer

## Refs

- Related issues: Feature request for [block explorer #97](https://github.com/rsksmart/rsk-explorer/issues/97)
