### PR TITLE
Docs: Reupdated ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This repo contains the RSK + RIF Developer Portal: [https://developers.rsk.co](https://developers.rsk.co)
 
-## Contributing
-We encourage you to contribute to the Developer's portal by sending a [PR](https://github.com/rsksmart/rsksmart.github.io/pulls) or [report issues](https://github.com/rsksmart/rsksmart.github.io/issues).
-
 ## Requirements
 
 ### Windows
@@ -204,13 +201,15 @@ This is **not** necessary for the development of the main site.
 
 ### Issues
 
-When you open an issue, you should be given the option to choose a category.
+We encourage you to [report issues](https://github.com/rsksmart/rsksmart.github.io/issues). When you open an issue, you should be given the option to choose a category.
 Choose the most appropriate one.
 
 Next, the description should be automatically populated from a template.
 Fill it in accordingly. Note that **What** and **Why** sections are compulsory, and the **Refs** section is optional.
 
 ### Pull Requests
+
+You can also contribute to the Developer's portal by sending a [PR](https://github.com/rsksmart/rsksmart.github.io/pulls).
 
 When you open a pull request, the description should be automatically populated
 from a template. Fill it in accordingly. Note that **What** and **Why** sections are compulsory, and the **Refs** section is optional.


### PR DESCRIPTION
## What

- Removed repeated contributing header and moved PR and submitting issues link to the previous header.

## Why

- There was a "contributing" header repetition in previous PR review

## Refs

- [PR](https://github.com/rsksmart/rsksmart.github.io/pull/298)
