### PR TITLE
feat: opt in feature bordered tables

### DIFF
--- a/_layouts/rsk.html
+++ b/_layouts/rsk.html
@@ -76,6 +76,8 @@
 
             {% include newsletter.html %}
          </div>
+         <div class="render-features" data-features="{{ page.render_features }}">
+         </div>
       </section>
 
       {% include footer.html %}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1641,6 +1641,30 @@ img {
   font-size:18px;
 }
 
+/* tables with borders */
+
+.table-with-border {
+    border: 0;
+    border-collapse: collapse;
+}
+
+.table-with-border thead,
+.table-with-border tbody,
+.table-with-border tfoot,
+.table-with-border tr,
+.table-with-border td,
+.table-with-border th {
+    border: inherit;
+    border-collapse: inherit;
+}
+
+.table-with-border tr,
+.table-with-border td,
+.table-with-border th {
+    border: 1px solid #ddd;
+    padding: 0.2em;
+}
+
 /* custom terminal render */
 
 .windows-command-prompt {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -55,6 +55,18 @@ if ( hash == '' || hash == '#' || hash == undefined ) return false;
 
 $(document).ready(function () {
   setUpMainSearch();
+  const renderFeatures = $('.render-features')
+    .data('features')
+    .split(/\s+/);
+  renderFeatures.forEach((feature) => {
+    switch (feature) {
+      case 'tables-with-borders':
+        renderTablesWithBorders();
+        return;
+      default:
+        console.error('Unsupported render feature:', feature);
+    }
+  });
 });
 
 // add active class to a in inner nav based on url
@@ -282,8 +294,13 @@ function renderCustomTerminals() {
     .addClass('windows-command-prompt')
 }
 
+function renderTablesWithBorders() {
+  $('table')
+    .addClass('table-with-border');
+}
+
 $('#newsletter-form').submit(function() {
-    
+
   var output = jQuery.map($(':checkbox[name=skillscb]:checked'), function (n, i) {
       return n.value;
   }).join(',');


### PR DESCRIPTION
## What

- now you can add `render_features: "tables-with-borders"` to a page's front matter for that particular page to opt into tables with borders

## Why

- the current way to do this is to use inline HTML within markdown, which is a code smell, and is best avoided
- preserve look and feel of existing pages while allowing new ones to opt in

## Refs

- [task](https://trello.com/c/4NKYjYID/339)
