### PR TITLE
fix: for green button word wrap issue

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -701,10 +701,9 @@ img {
 /*buttons*/
 
 .green-button {
+  display: inline-block;
+  margin: 4px 10px 0 0;
   background: #00b520;
-}
-
-.green-button {
   font-family: 'Quicksand', sans-serif;
   font-weight: 700;
   border: 0;


### PR DESCRIPTION
## What

- Applied CSS to prevent word wrap within `.green-button`

## Why

- On mobile devices, when there are more than 1 button together, the 2nd button may word wrap, and looks weird when this happen

## Refs

- [task](https://trello.com/c/60MyhWin/338)
- Fixes [#324](https://github.com/rsksmart/rsksmart.github.io/issues/324)
