### PR TITLE
fix: add missing metadata to all quickstart pages

### DIFF
--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -1,9 +1,11 @@
 ---
 layout: rsk
 title: Quick Start - Step 1
+tags: quick-start, rskj
+description: 'quick start - install RSK local node - prep environment, verify and install RSKj'
 collection_order: 10
 render_custom_terminals: true
-render_features: "custom-terminals"
+render_features: 'custom-terminals'
 ---
 
 # Step 1 : Install RSK local node

--- a/_quick-start/step2-install-truffle-and-ganache.md
+++ b/_quick-start/step2-install-truffle-and-ganache.md
@@ -1,6 +1,8 @@
 ---
 layout: rsk
 title: Quick Start - Step 2
+tags: quick-start, truffle, ganache
+description: 'quick start - tutorial project, install truffle, install ganache'
 collection_order: 20
 ---
 

--- a/_quick-start/step3-edit-smart-contract.md
+++ b/_quick-start/step3-edit-smart-contract.md
@@ -1,6 +1,8 @@
 ---
 layout: rsk
 title: Quick Start - Step 3
+tags: quick-start, solidity
+description: 'quick start - smart contracts, solidity'
 collection_order: 30
 ---
 

--- a/_quick-start/step4-compile-and-deploy.md
+++ b/_quick-start/step4-compile-and-deploy.md
@@ -1,6 +1,8 @@
 ---
 layout: rsk
 title: Quick Start - Step 4
+tags: quick-start, compile, deploy, regtest, truffle
+description: 'quick start - compile smart contracts, deploy smart contracts to regtest'
 collection_order: 40
 ---
 

--- a/_quick-start/step5-run-smart-contract.md
+++ b/_quick-start/step5-run-smart-contract.md
@@ -1,6 +1,8 @@
 ---
 layout: rsk
 title: Quick Start - Step 5
+tags: quick-start, smart-contract, truffle, web3
+description: 'quick start - smart contract interactions through web3 REPL'
 collection_order: 50
 ---
 
@@ -18,7 +20,7 @@ truffle console --network regtest
 
 ## Check Balance of Our EIP20 Token
 
-First, let's get the address of the account which was \
+First, let's get the address of the account which was
 used to deploy the contract.
 We shall save this in the variable `account1`.
 


### PR DESCRIPTION
## What

- add tags and description to frontmatter of all quick start pages

## Why

- this info was missing
