### PR TITLE
fix: double slash URLs + misc (2)

### DIFF
--- a/_includes/before-content.html
+++ b/_includes/before-content.html
@@ -1,5 +1,5 @@
 <div class="alert alert-info" role="alert">
-    <a href="https://developers.rsk.co/webinars?utm_source=devportal&utm_medium=infobar&utm_campaign=webinars" style="color: black!important;text-decoration: underline;">
+    <a href="/webinars?utm_source=devportal&utm_medium=infobar&utm_campaign=webinars" style="color: black!important;text-decoration: underline;">
         Join our Webinars! Now you can watch and learn more about Blockchain!
     </a>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
           <a class="nav-link" href="https://rsk.co/defi" target="_blank">Defi</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="https://developers.rsk.co/webinars" target="_blank">Webinars</a>
+          <a class="nav-link" href="/webinars" target="_self">Webinars</a>
         </li>
       </ul>
     </div>

--- a/_plugins/custom_links.rb
+++ b/_plugins/custom_links.rb
@@ -93,7 +93,7 @@ def get_relative_path(from_path, to_path)
   if (
     !to_path.to_s.include?('#') &&
     !relative_path&.end_with?(
-      '.js', '.css', '.png', '.svg', '.jpeg', '.jpg', '.html', '.htm'
+      '.js', '.css', '.png', '.svg', '.jpeg', '.jpg', '.html', '.htm', '.ical'
     )
   )
     relative_path = relative_path + '/'

--- a/_plugins/custom_links.rb
+++ b/_plugins/custom_links.rb
@@ -12,6 +12,7 @@ def customise_links!(p)
   site_redirect_base = p.site.config['redirect_base']
   from_url = p.url.to_s
   if (p.output_ext != '.html' && p.output_ext != '.htm')
+    # only process html pages
     return
   end
   if (p.permalink&.end_with?('.html', '.htm'))
@@ -64,6 +65,9 @@ def process_link_internal_absolute!(from_url, elem, attr_name)
   from_path = Pathname.new(from_url)
   to_path = Pathname.new(elem.get_attribute(attr_name))
   relative_path = get_relative_path(from_path, to_path)
+  # also handle any accidental redundant consecutive slashes
+  # e.g. foo//bar/baz --> foo/bar/baz
+  relative_path.gsub!(/\/{2,}/, '/')
   elem.set_attribute(attr_name, relative_path)
 end
 

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
             <a href="/quick-start">
             <div class="icon started h-100">
             <div class="icon-cont text-center my-auto">
-            <img src="assets/img/features/started-icon.png" alt="started icon">
+            <img src="/assets/img/features/started-icon.png" alt="started icon">
             </div>
             </div>
             </a><div class="content"><a href="/quick-start">
@@ -32,7 +32,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
             <a href="/rsk/node/install">
             <div class="icon node h-100">
             <div class="icon-cont text-center my-auto">
-            <img src="assets/img/features//node-icon.png" alt="started icon">
+            <img src="/assets/img/features/node-icon.png" alt="started icon">
             </div>
             </div>
             </a><div class="content"><a href="/rsk/node/install">
@@ -51,7 +51,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
             <a href="/develop">
             <div class="icon smart h-100">
             <div class="icon-cont text-center my-auto">
-            <img src="assets/img/features/contract-icon.png" alt="started icon">
+            <img src="/assets/img/features/contract-icon.png" alt="started icon">
             </div>
             </div>
             </a><div class="content two-line-title-content"><a href="/develop">
@@ -70,7 +70,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
             <a href="/rif">
             <div class="icon rif h-100">
             <div class="icon-cont text-center my-auto">
-            <img src="assets/img/features/rif-icon.png" alt="started icon">
+            <img src="/assets/img/features/rif-icon.png" alt="started icon">
             </div>
             </div>
             </a><div class="content"><a href="/rif">
@@ -89,7 +89,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
             <a href="/rif/rns">
             <div class="icon domain h-100">
             <div class="icon-cont text-center my-auto">
-            <img src="assets/img/features/domain-icon.png" alt="started icon">
+            <img src="/assets/img/features/domain-icon.png" alt="started icon">
             </div>
             </div>
             </a><div class="content"><a href="/rif/rns">
@@ -108,7 +108,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
             <a href="/rif/lumino">
             <div class="icon tools h-100">
             <div class="icon-cont text-center my-auto">
-            <img src="assets/img/features/tools-icon.png" alt="started icon">
+            <img src="/assets/img/features/tools-icon.png" alt="started icon">
             </div>
             </div>
             </a><div class="content"><a href="/rif/lumino">


### PR DESCRIPTION
## What

- fix for double-slash in URLs, e.g. `foo//bar/baz`
- fix for `.ical` links to remove trailing slash
- fix for webinar links to use same domain

## Why

- we don't want broken links, and the more we can automate detection/ prevention, the better

## Refs

- [task](https://trello.com/c/nBNOu6NL/371)
