### PR TITLE
fix: correct og-url in meta tags

### DIFF
--- a/_layouts/event_page.html
+++ b/_layouts/event_page.html
@@ -19,7 +19,7 @@
       <meta property="og:title" content="{{ event.title }} - RSK + RIF Webinars">
       <meta property="og:description" content="{{ event.description }} - RSK + RIF Webinars">
       <meta property="og:image" content="https://rsk.co/img/og/rsk.jpg">
-      <meta property="og:url" content="https://www.rsk.co/bounty-program">
+      <meta property="og:url" content="{{ site.url }}{{ page.url }}">
       <!-- Twitter Card data -->
       <meta name="twitter:card" content="summary">
       <meta name="twitter:title" content="{{ event.title }} - RSK + RIF Webinars">

--- a/_layouts/preso.html
+++ b/_layouts/preso.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="{{ event.title }} - RSK Developers' Portal">
     <meta property="og:description" content="{{ event.description }} - RSK Developers' Portal">
     <meta property="og:image" content="https://rsk.co/img/og/rsk.jpg">
-    <meta property="og:url" content="https://www.rsk.co/bounty-program">
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}">
     <!-- Twitter Card data -->
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{{ event.title }} - RSK Developers' Portal">

--- a/webinars/index.html
+++ b/webinars/index.html
@@ -17,9 +17,9 @@
       <title>Webinars</title>
       <!-- og info -->
       <meta property="og:title" content="Webinars">
-      <meta property="og:description" content="Security experts, software developers and hackers who dedicate time and effort to improve the rsk platform are rewarded. ">
+      <meta property="og:description" content="Welcome to RSK & RIF Webinars!">
       <meta property="og:image" content="https://rsk.co/img/og/rsk.jpg">
-      <meta property="og:url" content="https://www.rsk.co/bounty-program">
+      <meta property="og:url" content="{{ site.url }}/webinars/">
       <!-- Twitter Card data -->
       <meta name="twitter:card" content="summary">
       <meta name="twitter:title" content="Webinars">


### PR DESCRIPTION
## What

- correct the `og-url` meta tags to use the URL for this page

## Why

- get correct info displayed when sharing via sites that query open graph meta tags

## Refs

- [task](https://trello.com/c/KWlEyy3t/374)
