### PR TITLE
fix: add more extensions that do not get trailing slashes

### DIFF
--- a/_plugins/custom_links.rb
+++ b/_plugins/custom_links.rb
@@ -92,8 +92,8 @@ def get_relative_path(from_path, to_path)
   relative_path = to_path.relative_path_from(from_path).to_s
   if (
     !to_path.to_s.include?('#') &&
-    !relative_path&.end_with?(
-      '.js', '.css', '.png', '.svg', '.jpeg', '.jpg', '.html', '.htm', '.ical'
+    !relative_path&.downcase.end_with?(
+      '.js', '.css', '.png', '.svg', '.jpeg', '.jpg', '.html', '.htm', '.ical', '.conf', '.ico', '.gif', '.json', '.pdf'
     )
   )
     relative_path = relative_path + '/'


### PR DESCRIPTION
## What

- add more extensions that do not get trailing slashes in custom link post-processor

## Why

- files with these extensions should not be treated as web pages

## Refs

- [task](https://trello.com/c/JTA1v9Vy/383)
