### PR TITLE
docs: multi terminal instructions for rskj

### DIFF
--- a/_rsk/node/install/java.md
+++ b/_rsk/node/install/java.md
@@ -73,7 +73,7 @@ For further reference, check out the
 
 ## Check the RPC
 
-If you see no output, it means that the node is running. To check, you can open a new console tab (it is important you do not close this one or interrupt the process) and issue a request to the node's RPC HTTP server. This is an example using cURL:
+If you see no output, it means that the node is running. To confirm, you can open a new console tab (it is important you do not close this tab or interrupt the process) and issue a request to the node's RPC HTTP server. This is an example using cURL:
 
 [](#top "multiple-terminals")
 - Linux, Mac OSX

--- a/_rsk/node/install/java.md
+++ b/_rsk/node/install/java.md
@@ -2,6 +2,7 @@
 layout: rsk
 title: Setup node on Java
 collection_order: 2324
+render_features: 'custom-terminals'
 ---
 
 Make sure your system meets the [minimum requirements](../requirements/) before installing RSK nodes on it.
@@ -13,9 +14,16 @@ You also need to install [Java 8 JDK](https://www.java.com/download/).
 The Fat JAR or Uber JAR can be [downloaded](https://github.com/rsksmart/rskj/releases) or compiled (in a [reproducible way](https://github.com/rsksmart/rskj/wiki/Reproducible-Build) or [not](/rsk/node/contribute)).
 
 To run the node:
-```bash
-$ java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
-```
+
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```shell
+  $ java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
+  ```
+- Windows
+  ```windows-command-prompt
+  C:\> java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
+  ```
 
 Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-2.0.1-PAPYRUS-all.jar`
 
@@ -32,9 +40,15 @@ in a fraction of the time currently required.
 
 Use this command to run the node:
 
-```bash
-$ java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
-```
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```shell
+  $ java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
+  ```
+- Windows
+  ```windows-command-prompt
+  C:\> java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
+  ```
 
 If your hardware meets the
 [minimum hardware requirements](/rsk/node/install/requirements/),
@@ -42,9 +56,15 @@ but you get a memory error during the process,
 please consider adding the following flag to the command
 to change the memory allocated to the process:
 
-```bash
-$ java -Xmx4G -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
-```
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```shell
+  $ java -Xmx4G -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
+  ```
+- Windows
+  ```windows-command-prompt
+  C:\> java -Xmx4G -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
+  ```
 
 Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-2.0.1-PAPYRUS-all.jar`
 
@@ -55,11 +75,23 @@ For further reference, check out the
 
 If you see no output, it means that the node is running. To check, you can open a new console tab (it is important you do not close this one or interrupt the process) and issue a request to the node's RPC HTTP server. This is an example using cURL:
 
-```bash
-$ curl localhost:4444/1.1.0/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```shell
+  $ curl http://localhost:4444/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+  ```
+- Windows
+  ```windows-command-prompt
+  C:\> curl http://localhost:4444/ -X POST -H "Content-Type: application/json" --data '{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"params\":[],\"id\":1}'
+  ```
+
+The response should look similar to:
+
+```
+{"jsonrpc":"2.0","id":1,"result":"0xfc0"}
 ```
 
-The response should look similar to `{"jsonrpc":"2.0","id":1,"result":"0xfc0"}`, where the `result` property is the number of the latest block that has been synced (in hexadecimal).
+... where the `result` property is the number of the latest block that has been synced (in hexadecimal).
 
 ## Switching networks
 

--- a/_rsk/node/security-chain.md
+++ b/_rsk/node/security-chain.md
@@ -2,20 +2,20 @@
 layout: rsk
 title: Ensure security chain of RskJ source code
 tags: rsk, rskj, node, security, verification
-description: "All the different ways what you can verify RskJ: Release signing key, fingerprint of the public key, SHA256SUMS.asc, binary dependencies, secure environment script"
+description: "All the different ways what you can verify RSKj: Release signing key, fingerprint of the public key, SHA256SUMS.asc, binary dependencies, secure environment script"
 collection_order: 2500
 permalink: /rsk/node/security-chain/
 render_features: 'custom-terminals'
 ---
 
-# Verify authenticity of RskJ source code and its binary dependencies
+# Verify authenticity of RSKj source code and its binary dependencies
 
 The authenticity of the source code must be verified by checking the signature of the release tags in the official Git repository. The authenticity of the binary dependencies is verified by Gradle after following the steps below to install the necessary plugins.
 
 ## Download RSK Release Signing Key public key
 
-For Linux based OS (Ubuntu for example) it's recommended to install `curl` and `gnupg-curl` in order to download the key through HTTPS.
-We recommend using GPG v1 to download the public key because GPG v2 has problems to connect to HTTPS key servers. You can also download the key using curl, wget or a web browser but always check the fingerprint before importing it.
+For Linux based OS (Ubuntu for example), it's recommended to install `curl` and `gnupg-curl` in order to download the key through HTTPS.
+We recommend using GPG v1 to download the public key because GPG v2 encounters problems when connecting to HTTPS key servers. You can also download the key using curl, wget or a web browser but always check the fingerprint before importing it.
 
 [](#top "multiple-terminals")
 - Linux, Mac OSX

--- a/_rsk/node/security-chain.md
+++ b/_rsk/node/security-chain.md
@@ -5,6 +5,7 @@ tags: rsk, rskj, node, security, verification
 description: "All the different ways what you can verify RskJ: Release signing key, fingerprint of the public key, SHA256SUMS.asc, binary dependencies, secure environment script"
 collection_order: 2500
 permalink: /rsk/node/security-chain/
+render_features: 'custom-terminals'
 ---
 
 # Verify authenticity of RskJ source code and its binary dependencies
@@ -16,38 +17,44 @@ The authenticity of the source code must be verified by checking the signature o
 For Linux based OS (Ubuntu for example) it's recommended to install `curl` and `gnupg-curl` in order to download the key through HTTPS.
 We recommend using GPG v1 to download the public key because GPG v2 has problems to connect to HTTPS key servers. You can also download the key using curl, wget or a web browser but always check the fingerprint before importing it.
 
-``` bash
-$ gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 5DECF4415E3B8FA4
-gpg: requesting key 5E3B8FA4 from https server secchannel.rsk.co
-gpg: key 5E3B8FA4: public key "RSK Release Signing Key <support@rsk.co>" imported
-gpg: Total number processed: 1
-gpg:               imported: 1  (RSA: 1)
-```
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```bash
+  $ gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 5DECF4415E3B8FA4
+  gpg: requesting key 5E3B8FA4 from https server secchannel.rsk.co
+  gpg: key 5E3B8FA4: public key "RSK Release Signing Key <support@rsk.co>"      imported
+  gpg: Total number processed: 1
+  gpg:               imported: 1  (RSA: 1)
+  ```
 
 ## Verify the fingerprint of the public key
 
-``` bash
-$ gpg --finger 5DECF4415E3B8FA4
-pub   4096R/5E3B8FA4 2017-05-16 [expires: 2022-05-15]
-      Key fingerprint = 1A92 D894 2171 AFA9 51A8  5736 5DEC F441 5E3B 8FA4
-uid                  RSK Release Signing Key <support@rsk.co>
-sub   4096R/A44DCC86 2017-05-16 [expires: 2022-05-15]
-sub   4096R/5E488E87 2017-05-16 [expires: 2022-05-15]
-sub   4096R/9FC3E7C2 2017-05-16 [expires: 2022-05-15]
-```
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ``` bash
+  $ gpg --finger 5DECF4415E3B8FA4
+  pub   4096R/5E3B8FA4 2017-05-16 [expires: 2022-05-15]
+        Key fingerprint = 1A92 D894 2171 AFA9 51A8  5736 5DEC F441 5E3B 8FA4
+  uid                  RSK Release Signing Key <support@rsk.co>
+  sub   4096R/A44DCC86 2017-05-16 [expires: 2022-05-15]
+  sub   4096R/5E488E87 2017-05-16 [expires: 2022-05-15]
+  sub   4096R/9FC3E7C2 2017-05-16 [expires: 2022-05-15]
+  ```
 
 ## Verify the signature of SHA256SUMS.asc
 
 The file`SHA256SUMS.asc` is signed with RSK public key and includes SHA256 hashes of the files necessary to start the build process.
 
-```bash
-$ gpg --verify SHA256SUMS.asc
-gpg: Signature made mar 16 may 2017 16:47:56 ART
-gpg:                using RSA key 0x67D06695A44DCC86
-gpg: Good signature from "RSK Release Signing Key <support@rsk.co>" [ultimate]
-Primary key fingerprint: 1A92 D894 2171 AFA9 51A8  5736 5DEC F441 5E3B 8FA4
-     Subkey fingerprint: D135 DDC0 B54D 6EF3 5901  52DF 67D0 6695 A44D CC86
-```
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```bash
+  $ gpg --verify SHA256SUMS.asc
+  gpg: Signature made mar 16 may 2017 16:47:56 ART
+  gpg:                using RSA key 0x67D06695A44DCC86
+  gpg: Good signature from "RSK Release Signing Key <support@rsk.co>" [ultimate]
+  Primary key fingerprint: 1A92 D894 2171 AFA9 51A8  5736 5DEC F441 5E3B 8FA4
+      Subkey fingerprint: D135 DDC0 B54D 6EF3 5901  52DF 67D0 6695 A44D CC86
+  ```
 
 *Note:* Learn more about [key management](https://www.gnupg.org/gph/en/manual/x334.html) here.
 
@@ -57,22 +64,24 @@ The authenticity of the script `configure.sh` is checked using the `sha256sum` c
 
 Linux - Windows (bash console)
 
-```bash
-$ sha256sum --check SHA256SUMS.asc
-configure.sh: OK
-sha256sum: WARNING: 19 lines are improperly formatted
-```
-
-MacOs
-
-```bash
-$ shasum --check SHA256SUMS.asc
-configure.sh: OK
-sha256sum: WARNING: 19 lines are improperly formatted
-```
+[](#top "multiple-terminals")
+- Linux
+  ```bash
+  $ sha256sum --check SHA256SUMS.asc
+  configure.sh: OK
+  sha256sum: WARNING: 19 lines are improperly formatted
+  ```
+- Mac OSX
+  ```bash
+  $ shasum --check SHA256SUMS.asc
+  configure.sh: OK
+  sha256sum: WARNING: 19 lines are improperly formatted
+  ```
 
 ## Run configure script to configure secure environment
 
-```bash
-$ ./configure.sh
-```
+[](#top "multiple-terminals")
+- Linux, Mac OSX
+  ```bash
+  $ ./configure.sh
+  ```


### PR DESCRIPTION
## What

- modify existing articles to render command line instructions using multiple terminals, example:
  - ![image](https://user-images.githubusercontent.com/1773785/85673107-22c88c80-b6f6-11ea-8e43-6881d1fb2461.png)
  - ![image](https://user-images.githubusercontent.com/1773785/85673149-2e1bb800-b6f6-11ea-8566-72a9c6c25472.png)


## Why

- improve UX, where command differ slightly between different operating systems

## Refs

- [task](https://trello.com/c/PZIAE9kR/390)
- related PRs: [#374](https://github.com/rsksmart/devportal/pull/374), [#371](https://github.com/rsksmart/devportal/pull/371)