### PR TITLE
docs: add link to rskj's expected.conf

### DIFF
--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -6,6 +6,16 @@ description: "Configuration reference for RSKj"
 collection_order: 2410
 ---
 
+## Advanced Configuration
+
+For advanced configuration requirements, please refer to this
+[expected configuration file](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/expected.conf).
+This contains all possible configuration fields parsed by RSKj.
+
+## Guide
+
+The following detail the most commonly used configuration fields parsed by RSKj.
+
 - [`peer`](#peer)
 - [`database`](#database)
 - [`database.import`](#databaseimport)


### PR DESCRIPTION
## What

- Added a link to https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/expected.conf in `/rsk/node/configure/reference/`

## Why

- current config reference page details a subset of all the available config options
- advanced users may require the use of other config options and thus need this reference

## Refs

- [task](https://trello.com/c/XnSwHexl/393)
