### PR TITLE
Update testnet federation address and remove quotes

### DIFF
--- a/tools/tokenbridge/contractaddresses.md
+++ b/tools/tokenbridge/contractaddresses.md
@@ -7,36 +7,34 @@ title: Addresses and Links
 
 ### On RSK
 
-  - "bridge": [0x9d11937e2179dc5270aa86a3f8143232d6da0e69](https://explorer.rsk.co/address/0x9d11937e2179dc5270aa86a3f8143232d6da0e69)
-  - "federation": [0xac42761c37d4467ff69082249b9e67d6b35d50cb](https://explorer.rsk.co/address/0xac42761c37d4467ff69082249b9e67d6b35d50cb)
-  - "allowTokens": [0xe4aa0f414725c9322a1a9d80d469c5e234786653](https://explorer.rsk.co/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
-  - "multiSigWallet": [0x040007b1804ad78a97f541bebed377dcb60e4138](https://explorer.rsk.co/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
-  - "RIF": [0x2acc95758f8b5f583470ba265eb685a8f45fc9d5](https://explorer.rsk.co/address/0x2acc95758f8b5f583470ba265eb685a8f45fc9d5)
+  - Bridge: [`0x9d11937e2179dc5270aa86a3f8143232d6da0e69`](https://explorer.rsk.co/address/0x9d11937e2179dc5270aa86a3f8143232d6da0e69)
+  - Federation: [`0xac42761c37d4467ff69082249b9e67d6b35d50cb`](https://explorer.rsk.co/address/0xac42761c37d4467ff69082249b9e67d6b35d50cb)
+  - AllowTokens: [`0xe4aa0f414725c9322a1a9d80d469c5e234786653`](https://explorer.rsk.co/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
+  - MultiSigWallet: [`0x040007b1804ad78a97f541bebed377dcb60e4138`](https://explorer.rsk.co/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
 
 ### On Ethereum
 
-  - "bridge": ["0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d"](https://etherscan.io/address/0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d)
-  - "federation": ["0x8c1901c031cdf42a846c0c422a3b5a2c943f4944"](https://etherscan.io/address/0x8c1901c031cdf42a846c0c422a3b5a2c943f4944)
-  - "allowTokens": [0xe4aa0f414725c9322a1a9d80d469c5e234786653](https://etherscan.io/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
-  - "multiSigWallet": [0x040007b1804ad78a97f541bebed377dcb60e4138](https://etherscan.io/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
+  - Bridge: [`0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d`](https://etherscan.io/address/0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d)
+  - Federation: [`0x8c1901c031cdf42a846c0c422a3b5a2c943f4944`](https://etherscan.io/address/0x8c1901c031cdf42a846c0c422a3b5a2c943f4944)
+  - AllowTokens: [`0xe4aa0f414725c9322a1a9d80d469c5e234786653`](https://etherscan.io/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
+  - MultiSigWallet: [`0x040007b1804ad78a97f541bebed377dcb60e4138`](https://etherscan.io/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
 
 # Testnet Addresses and Links
 
 ### On RSK Testnet
 
-  - "bridge": [0x684a8a976635fb7ad74a0134ace990a6a0fcce84](https://explorer.testnet.rsk.co/address/0x684a8a976635fb7ad74a0134ace990a6a0fcce84)
-  - "federation": [0x36c893a955399cf15a4a2fbef04c0e06d4d9b379](https://explorer.testnet.rsk.co/address/0x36c893a955399cf15a4a2fbef04c0e06d4d9b379)
-  - "allowTokens": [0x952b706a9ab5fd2d3b36205648ed7852676afbe7](https://explorer.testnet.rsk.co/address/0x952b706a9ab5fd2d3b36205648ed7852676afbe7)
-  - "multiSigWallet": [0x88f6b2bc66f4c31a3669b9b1359524abf79cfc4a](https://explorer.testnet.rsk.co/address/0x88f6b2bc66f4c31a3669b9b1359524abf79cfc4a)
-  - "tRIF": [0x19f64674d8a5b4e652319f5e239efd3bc969a1fe](https://explorer.testnet.rsk.co/address/0x19f64674d8a5b4e652319f5e239efd3bc969a1fe)
+  - Bridge_v1: [`0x684a8a976635fb7ad74a0134ace990a6a0fcce84`](https://explorer.testnet.rsk.co/address/0x684a8a976635fb7ad74a0134ace990a6a0fcce84)
+  - Federation_v1: [`0x925606edc5863c079b712daed560c31eff8335b9`](https://explorer.testnet.rsk.co/address/0x925606edc5863c079b712daed560c31eff8335b9)
+  - AllowTokens: [`0x952b706a9ab5fd2d3b36205648ed7852676afbe7`](https://explorer.testnet.rsk.co/address/0x952b706a9ab5fd2d3b36205648ed7852676afbe7)
+  - MultiSigWallet: [`0x88f6b2bc66f4c31a3669b9b1359524abf79cfc4a`](https://explorer.testnet.rsk.co/address/0x88f6b2bc66f4c31a3669b9b1359524abf79cfc4a)
+ 
 
 ### On Kovan
 
-  - "bridge": ["0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d"](https://kovan.etherscan.io/address/0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d)
-  - "federation": ["0x8c1901c031cdf42a846c0c422a3b5a2c943f4944"](https://kovan.etherscan.io/address/0x8c1901c031cdf42a846c0c422a3b5a2c943f4944)
-  - "allowTokens": [0xe4aa0f414725c9322a1a9d80d469c5e234786653](https://kovan.etherscan.io/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
-  - "multiSigWallet": [0x040007b1804ad78a97f541bebed377dcb60e4138](https://kovan.etherscan.io/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
-  - "etRIF": [0x69f6d4d4813f8e2e618dae7572e04b6d5329e207](https://kovan.etherscan.io/address/0x69f6d4d4813f8e2e618dae7572e04b6d5329e207)
+  - Bridge_v1: [`0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d`](https://kovan.etherscan.io/address/0x12ed69359919fc775bc2674860e8fe2d2b6a7b5d)
+  - Federation_v1: [`0xda2295255633c26eaadbace5269b6e8bd2648ca0`](https://kovan.etherscan.io/address/0xda2295255633c26eaadbace5269b6e8bd2648ca0)
+  - AllowTokens: [`0xe4aa0f414725c9322a1a9d80d469c5e234786653`](https://kovan.etherscan.io/address/0xe4aa0f414725c9322a1a9d80d469c5e234786653)
+  - MultiSigWallet: [`0x040007b1804ad78a97f541bebed377dcb60e4138`](https://kovan.etherscan.io/address/0x040007b1804ad78a97f541bebed377dcb60e4138)
 
 ## List of ABIs
 


### PR DESCRIPTION
## What

- Update testnet federation address
- Remove quotes from addresses
- Use the same name as the actual contract deployed

## Why

- Testnet Token Bridge has been updated to version 1.0.0  on testnet
- The removal of the quotes and use the same name as the contract deployed helps to give clarity

## Refs

- Token Bridge 1.0.0 https://github.com/rsksmart/tokenbridge/releases/tag/1.0.0-testnet
