### PR TITLE
feat: define more fitting default slide dimensions attributes

### DIFF
--- a/_layouts/preso.html
+++ b/_layouts/preso.html
@@ -66,6 +66,13 @@
         progress: true,
         history: true,
         center: true,
+
+        width: 1200,
+        height: 675,
+        margin: 0.08,
+        minScale: 0.5,
+        maxScale: 2.0,
+
         plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]
       });
     </script>


### PR DESCRIPTION
## What

- define more fitting default slide dimensions attributes

## Why

- some slides with more text had overlap with the slide background images, minimising this

## Refs

- [task](https://trello.com/c/8qdNjY1P/434)
