### PR TITLE
Remove node version from sample URL

### DIFF
--- a/_rsk/public-nodes.md
+++ b/_rsk/public-nodes.md
@@ -77,7 +77,7 @@ These nodes support the following JSON RPC methods:
 Here's an example request using `cURL` to get the Mainnet block number:
 
 ```shell
-curl https://public-node.rsk.co/1.1.0/ \
+curl https://public-node.rsk.co \
     -X POST -H "Content-Type: application/json" \
     --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```


### PR DESCRIPTION
## Why

Node version 1.1.0 was not up to date. It can be safely removed since `https://public-node.rsk.co` points to the last version of RSKj. Hence, there is no need to point to a specific version number.
