### PR TITLE
typo in command

### DIFF
--- a/tutorials/workshop-smart-contract-testing-ozcli.md
+++ b/tutorials/workshop-smart-contract-testing-ozcli.md
@@ -83,7 +83,7 @@ Ensure that you have a copy of RSKj running in Regtest locally,
 and then run the set up script:
 
 ```shell
-bash ./scripts.setup.sh
+bash ./scripts/setup.sh
 ```
 
 This will set up the RSK specific files for this project

--- a/webinars/202008-005/slides.md
+++ b/webinars/202008-005/slides.md
@@ -11,7 +11,7 @@ backgroundImage: "/assets/img/preso/preso-rsk-slide-body.png"
 
 ---
 
-# Testing Smart Contracts with Truffle
+# Testing Smart Contracts with OZ CLI
 
 [Brendan Graetz](http://bguiz.com/)
 


### PR DESCRIPTION


## What

-  typo in command line  (bash ./scripts.setup.shbash   =>  ./scripts/setup.shbash ./scripts/setup.sh

## Why

-  no such file or directory: /scripts.setup.sh

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
