### PR TITLE
remove compatibility matrix of 2-way-peg & more things

### DIFF
--- a/_rsk/rbtc/conversion/index.md
+++ b/_rsk/rbtc/conversion/index.md
@@ -5,7 +5,7 @@ tags: rsk, rbtc, conversion, peg, 2-way, peg-in, peg-out, federation
 description: 'Converting R-BTC to BTC (peg-in) and BTC to R-BTC (peg-out), for both Mainnet and Testnet.'
 collection_order: 3100
 permalink: /rsk/rbtc/conversion/
-render_features: '2-way-peg-verifier tables-with-borders'
+render_features: '2-way-peg-verifier'
 ---
 
 In this article we will explain step by step on how to convert from BTC to R-BTC, and vice versa.
@@ -21,36 +21,11 @@ Thus, these conversions are referred to as peg-ins and peg-outs.
   - Locks R-BTC on the RSK network
   - Releases BTC on the Bitcoin network
 
-## Compatibility Matrix
+## Compatibility
 
-In the following matrixes will be shown the different types of addresses that are accepted for the Federation.
-
-| Before Papyrus | | Accepted in BTC | | Accepted in RSK | | Refundable | | Processable |
-| :-- | | --- | | :---: | | --- | | :---: | | --- | | :---: | | --- | | :---: |
-| P2PKH | | ✔ | | ✔ | | ✔ | | ✔ |
-| P2SH-P2WPKH | | ✔ | | ❌ | | ❌ | | ❌ |
-| P2SH-MULTISIG | | ✔ | | ❌ | | ❌ | | ❌ |
-| P2SH-P2WSH | | ✔ | | ❌ | | ❌ | | ❌ |
-| PWPKH (BECH32) | | ✔ | | ❌ | | ❌ | | ❌ |
-| OTHERS | | ✔ | | ❌ | | ❌ | | ❌ |
-
-<br/>
-
-| After Papyrus | | Accepted in BTC | | Accepted in RSK | | Refundable | | Processable |
-| :-- | | --- | | :---: | | --- | | :---: | | --- | | :---: | | --- | | :---: |
-| P2PKH | | ✔ | | ✔ | | ✔ | | ✔ |
-| P2SH-P2WPKH | | ✔ | | ✔ | | ✔ | | ✔ |
-| P2SH-MULTISIG | | ✔ | | ✔ | | ✔ | | ❌ |
-| P2SH-P2WSH | | ✔ | | ✔ | | ✔ | | ❌ |
-| PWPKH (BECH32) | | ✔ | | ❌ | | ❌ | | ❌ |
-| OTHERS | | ✔ | | ❌ | | ❌ | | ❌ |
-
-<br/>
-
-- **Accepted in BTC**: Is this type of address accepted in regular BTC transactions? (including sending BTC to the Federation address)
-- **Accepted in RSK**: is this type of address received by RSK Bridge smart contract?
-- **Refundable**: is this type of address able to generate a refund transaction (this occurs when the transaction won't be processable, then we refund the sender its BTC)
-- **Processable**: is this type of address able to generate a refund transaction (this occurs when the transaction won't be processable, then we refund the sender its BTC)
+**The types of addresses that are accepted for the Federation are**:
+- Legacy (P2PKH)
+- Segwit Compatible (P2SH-P2WPKH)
 
 > Note: On the Testnets, the token symbols are prefixed with a lowercase `t`.
 > Thus we have `BTC` and `R-BTC` on the Mainnets,

--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -35,8 +35,7 @@ and here we recommend to use Electrum BTC wallet for connecting to BTC Mainnet.
 **2 Send Bitcoin to RSK Federation address**
 
 <div class="fade alert alert-warning show">
-Note: You need to send a minimum amount of 0.01 BTC and
-not more than 10 BTC for conversion.
+Note: You need to send a minimum amount of 0.01 BTC.
 </div>
 
 The RSK Federation address is retrieved by making a Smart Contract call
@@ -59,7 +58,7 @@ To ensure the transaction, we need to wait 100 BTC confirmations, be patient :)
 
 **4 Get R-BTC address with BTC private key**
 
-You can get a corresponding R-BTC address with your BTC private key from [https://github.com/rsksmart/utils](https://github.com/rsksmart/utils).
+You can get a corresponding R-BTC address from your BTC private key by using [github.com/rsksmart/utils](https://github.com/rsksmart/utils). If you do not want to compile the utility, you can download the [latest release](https://github.com/rsksmart/utils/releases/latest).
 
 > Note: when entering Bitcoin private key do not include _p2pkh:_ in the front.
 
@@ -77,7 +76,7 @@ Instructions on how to do a Mainnet peg-out.
 
 **1 Get BTC address with R-BTC private key**
 
-If you forgot BTC public address you can retrieve it with RSK private key from [https://github.com/rsksmart/utils](https://github.com/rsksmart/utils).
+You can get a corresponding BTC address from your R-BTC private key by using [github.com/rsksmart/utils](https://github.com/rsksmart/utils). If you do not want to compile the utility, you can download the [latest release](https://github.com/rsksmart/utils/releases/latest).
 
 **2 Send R-BTC to RSK Bridge Contract**
 

--- a/_rsk/rbtc/conversion/networks/testnet.md
+++ b/_rsk/rbtc/conversion/networks/testnet.md
@@ -64,7 +64,7 @@ you can send Bitcoin to it from your Bitcoin address.
 
 **4 Get tR-BTC address with tBTC private key**
 
-You can get a corresponding tR-BTC address with your tBTC private key from [https://github.com/rsksmart/utils](https://github.com/rsksmart/utils).
+You can get a corresponding tR-BTC address from your tBTC private key by using [github.com/rsksmart/utils](https://github.com/rsksmart/utils). If you do not want to compile the utility, you can download the [latest release](https://github.com/rsksmart/utils/releases/latest).
 
 > Note: when entering Bitcoin private key do not include _p2pkh:_ in the front.
 
@@ -82,8 +82,7 @@ Instructions on how to do a Testnet peg-out.
 
 **1 Get tBTC address with tR-BTC private key**
 
-If you forgot tBTC public address you can retrieve it with RSK private key
-from [https://github.com/rsksmart/utils](https://github.com/rsksmart/utils).
+You can get a corresponding tBTC address from your tR-BTC private key by using [github.com/rsksmart/utils](https://github.com/rsksmart/utils). If you do not want to compile the utility, you can download the [latest release](https://github.com/rsksmart/utils/releases/latest).
 
 **2 Send tR-BTC to RSK Bridge Contract**
 


### PR DESCRIPTION
## What

Remove the compatibility matrix of 2-way-peg. It was referenced to https://github.com/rsksmart/utils/releases/.

## Why

- To improved the user experience
