### PR TITLE
add enabling contract data information for ledger

### DIFF
--- a/wallet/use/ledger.md
+++ b/wallet/use/ledger.md
@@ -45,7 +45,7 @@ Afterward, the device will also show the RSK app's icon:
 
 ### 4. Use RSK
 
-Open your RSK app in your device and let the display show the ‘Use wallet to view accounts’ legend: 
+Open the RSK app in your device and let the display show the ‘Use wallet to view accounts’ legend: 
 
 ![Ledger RSK App](/assets/img/rsk/ledger/7.png)
 

--- a/wallet/use/ledger.md
+++ b/wallet/use/ledger.md
@@ -48,3 +48,15 @@ Afterward, the device will also show the RSK app's icon:
 Open your RSK app in your device and let the display show the ‘Use wallet to view accounts’ legend: 
 
 ![Ledger RSK App](/assets/img/rsk/ledger/7.png)
+
+
+### 5. Enabling contract data
+If you want to send ERC-20 tokens, you need to activate contract data on your device. Otherwise, **invalid status 6a80** is returned.
+
+To enable contract data: 
+
+1. Connect and unlock your Ledger device.
+2. Open the **RSK** application.
+3. Press the right button to navigate to **Settings**. Then press both buttons to validate.
+4. In the **Contract data** settings, press both buttons to allow contract data in transactions. 
+The device displays **Allowed**.


### PR DESCRIPTION
## What

- Adding enabling contract data information for Ledger wallet

## Why

- it is important to let you know to the users how to transfer erc20 tokens.

## Refs

- https://support.ledger.com/hc/en-us/articles/115005200009-Set-up-and-use-MyEtherWallet
