### PR TITLE
docs: add link to wallets page in rbtc and rif token pages

### DIFF
--- a/_rsk/rbtc/index.md
+++ b/_rsk/rbtc/index.md
@@ -78,6 +78,9 @@ The Smart Bitcoin (R-BTC) is the token used to [pay for the execution](/rsk/rbtc
   </tbody>
 </table>
 
+## Wallets
+
+See [supported wallets](/wallet/use/).
 
 ## Exchanges
 

--- a/rif/token.md
+++ b/rif/token.md
@@ -76,6 +76,10 @@ The RIF Token allows any token holder to consume the services that are compatibl
   </tbody>
 </table>
 
+## Wallets
+
+See [supported wallets](/wallet/use/).
+
 ## Exchanges
 
 <div class="owl-carousel owl-theme">


### PR DESCRIPTION
## What

- add link to wallets page in rbtc and rif token pages

## Why

- make it easier to find

## Refs

- [task](https://trello.com/c/l6pnEBDh/524)
