### PR TITLE
Explains how to configure a Trezor T to access custom dpath

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -128,6 +128,7 @@
                   </ul>
                   <li><a href="/rsk/rbtc/conversion/with-ledger/">With Ledger</a></li>
                   <li><a href="/rsk/rbtc/conversion/with-node-and-console/">With CLI</a></li>
+                  <li><a href="/rsk/rbtc/conversion/with-trezor-t/">With Trezor T</a></li>
                 </ul>
               </li>
               <li><a href="/rsk/rbtc/gas/">Gas</a></li>

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -21,7 +21,7 @@ In MyCrypto or MyEtherWallet you may have received this message: `"Forbidden key
 
 To allow custom derivation paths, you will need to turn off safety checks (see [Pavol Rusnak message](https://github.com/trezor/trezor-firmware/issues/1255#issuecomment-691463540)).
 
-To do this, you need first to install [python-trezor](https://github.com/trezor/python-trezor):
+To do this, you need to install [python-trezor](https://github.com/trezor/python-trezor):
 
 ```shell
 pip3 install --upgrade setuptools

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -11,7 +11,7 @@ be derived with a custom derivation path (dpath) using Trezor T.
 
 ## General context
 
-If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the dpath matches with the expected one as a safety feature and this is a blocker when you intend to use a different dpath.
+If you made a [BTC to R-BTC conversion](/rsk/rbtc/conversion/with-ledger#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the dpath matches with the expected one as a safety feature and this is a blocker when you intend to use a different dpath.
 You may also want to access your account with a different dpath if you made a mistake; for example, receiving RBTC at an address derived using the Ethereum dpath instead of the RSK dpath.
 
 In MyCrypto or MyEtherWallet you may have received this message: `"Forbidden key path"`.

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -11,7 +11,7 @@ be derived with a custom derivation path (dpath) using Trezor T.
 
 ## General context
 
-If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the derivation path matches with the expected one as a safety feature and this is a blocker when you need to consciously use a different dpath.
+If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the dpath matches with the expected one as a safety feature and this is a blocker when you intend to use a different dpath.
 You may also want to access your account with a different dpath if you made a mistake like receiving RBTC in an Ethereum address.
 
 You probably tried to do it in MyCrypto or MyEtherWallet and you got this message: `"Forbidden key path"`.

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -1,0 +1,43 @@
+---
+layout: rsk
+title: Accessing and using funds that are not in accounts derived with RSK dpath in Trezor T
+tags: rsk, rbtc, conversion, peg, 2-way, peg-in, peg-out, federation, trezor, dpath
+description: 'How to configure a Trezor T hardware wallet to derive with a custom dpath'
+collection_order: 3160
+---
+
+This section is meant to explain how to solve the problem of moving your funds when they are in a account that needs to
+be derived with a different derivation path using Trezor T.
+
+## General context
+
+If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the derivation path matches with the expected one as a safety feature and this is a blocker when you need to consciously use a different dpath.
+You may also want to access your account with a different dpath if you made a mistake like receiving RBTC in an Ethereum address.
+
+You probably tried to do it in MyCrypto or MyEtherWallet and you got this message: `"Forbidden key path"`.
+
+
+## Solution
+
+To allow custom derivation paths, you will need to turn off safety checks (see [Pavol Rusnak message](https://github.com/trezor/trezor-firmware/issues/1255#issuecomment-691463540)).
+
+To do this, you need first to install [python-trezor](https://github.com/trezor/python-trezor):
+
+```shell
+pip3 install --upgrade setuptools
+pip3 install trezor
+```
+
+Once you are ready, run this command:
+
+```shell
+trezorctl set safety-checks prompt
+```
+(you need to have your Trezor T unlocked and accept the configuration in the device)
+
+After moving your funds, you can turn them on again:
+
+```shell
+trezorctl set safety-checks strict
+```
+

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -14,7 +14,7 @@ be derived with a custom derivation path (dpath) using Trezor T.
 If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the dpath matches with the expected one as a safety feature and this is a blocker when you intend to use a different dpath.
 You may also want to access your account with a different dpath if you made a mistake like receiving RBTC in an Ethereum address.
 
-You probably tried to do it in MyCrypto or MyEtherWallet and you got this message: `"Forbidden key path"`.
+In MyCrypto or MyEtherWallet you may have received this message: `"Forbidden key path"`.
 
 
 ## Solution

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -6,8 +6,8 @@ description: 'How to configure a Trezor T hardware wallet to derive with a custo
 collection_order: 3160
 ---
 
-This section is meant to explain how to solve the problem of moving your funds when they are in a account that needs to
-be derived with a different derivation path using Trezor T.
+How to solve the problem of moving your funds when they are in a account that needs to
+be derived with a custom derivation path (dpath) using Trezor T.
 
 ## General context
 
@@ -40,4 +40,3 @@ After moving your funds, you can turn them on again:
 ```shell
 trezorctl set safety-checks strict
 ```
-

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -6,7 +6,7 @@ description: 'How to configure a Trezor T hardware wallet to derive with a custo
 collection_order: 3160
 ---
 
-How to solve the problem of moving your funds when they are in a account that needs to
+How to solve the problem of moving your funds when they are in an account that needs to
 be derived with a custom derivation path (dpath) using Trezor T.
 
 ## General context

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -12,7 +12,7 @@ be derived with a custom derivation path (dpath) using Trezor T.
 ## General context
 
 If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the dpath matches with the expected one as a safety feature and this is a blocker when you intend to use a different dpath.
-You may also want to access your account with a different dpath if you made a mistake like receiving RBTC in an Ethereum address.
+You may also want to access your account with a different dpath if you made a mistake; for example, receiving RBTC at an address derived using the Ethereum dpath instead of the RSK dpath.
 
 In MyCrypto or MyEtherWallet you may have received this message: `"Forbidden key path"`.
 


### PR DESCRIPTION
## What

- Adds the explanation about how to configure a Trezor T to access a custom dpath, necessary if it was used to go through the bridge.

## Why

- Can't sign transactions if the dpath is not the expected one

## Refs

- https://github.com/trezor/trezor-firmware/issues/1255
