### PR TITLE
Fix minimum peg out

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -128,6 +128,7 @@
                   </ul>
                   <li><a href="/rsk/rbtc/conversion/with-ledger/">With Ledger</a></li>
                   <li><a href="/rsk/rbtc/conversion/with-node-and-console/">With CLI</a></li>
+                  <li><a href="/rsk/rbtc/conversion/with-trezor-t/">With Trezor T</a></li>
                 </ul>
               </li>
               <li><a href="/rsk/rbtc/gas/">Gas</a></li>

--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -82,7 +82,7 @@ You can get a corresponding BTC address from your R-BTC private key by using [gi
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> Note: The minimum amount to send is 0.008 R-BTC for Mainnet
+> Note: The minimum amount to send must be greater than 0.008 R-BTC for Mainnet;
 > Gas Limit of the transaction needs to be manually set at 100,000 gas;
 > otherwise the transaction will fail. Gas Price can be set to 0.06 gwei.
 

--- a/_rsk/rbtc/conversion/with-ledger.md
+++ b/_rsk/rbtc/conversion/with-ledger.md
@@ -197,7 +197,7 @@ Then do a transaction to the Bridge Contract.
 
 Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> Note: The minimum amount to send is 0.008 R-BTC for Mainnet
+> Note: The minimum amount to send must be greater than 0.008 R-BTC for Mainnet;
 > Gas Limit of the transaction needs to be manually set at 100,000 gas;
 > otherwise the transaction will fail.
 > Gas Price can be set to 0.06 gwei.

--- a/_rsk/rbtc/conversion/with-trezor-t.md
+++ b/_rsk/rbtc/conversion/with-trezor-t.md
@@ -1,0 +1,43 @@
+---
+layout: rsk
+title: Accessing and using funds that are not in accounts derived with RSK dpath in Trezor T
+tags: rsk, rbtc, conversion, peg, 2-way, peg-in, peg-out, federation, trezor, dpath
+description: 'How to configure a Trezor T hardware wallet to derive with a custom dpath'
+collection_order: 3160
+---
+
+This section is meant to explain how to solve the problem of moving your funds when they are in a account that needs to
+be derived with a different derivation path using Trezor T.
+
+## General context
+
+If you made a [BTC to R-BTC conversion](#btc-to-r-btc-conversion) using Trezor T, you need to access your account by using a custom dpath (`44'/0'/0'/0/0` for Mainnet). With the last firmware versions, Trezor T is checking that the derivation path matches with the expected one as a safety feature and this is a blocker when you need to consciously use a different dpath.
+You may also want to access your account with a different dpath if you made a mistake like receiving RBTC in an Ethereum address.
+
+You probably tried to do it in MyCrypto or MyEtherWallet and you got this message: `"Forbidden key path"`.
+
+
+## Solution
+
+To allow custom derivation paths, you will need to turn off safety checks (see [Pavol Rusnak message](https://github.com/trezor/trezor-firmware/issues/1255#issuecomment-691463540)).
+
+To do this, you need first to install [python-trezor](https://github.com/trezor/python-trezor):
+
+```shell
+pip3 install --upgrade setuptools
+pip3 install trezor
+```
+
+Once you are ready, run this command:
+
+```shell
+trezorctl set safety-checks prompt
+```
+(you need to have your Trezor T unlocked and accept the configuration in the device)
+
+After moving your funds, you can turn them on again:
+
+```shell
+trezorctl set safety-checks strict
+```
+


### PR DESCRIPTION
## What

- DevPortal shows wrongly the minimum peg out value (strict equal instead of `greater than`)

## Why

- Avoid people loosing their funds

