### PR TITLE
Fix wrong minimum in peg out

### DIFF
--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -82,7 +82,7 @@ You can get a corresponding BTC address from your R-BTC private key by using [gi
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> Note: The minimum amount to send is 0.008 R-BTC for Mainnet
+> Note: The minimum amount to send must be greater than 0.008 R-BTC for Mainnet;
 > Gas Limit of the transaction needs to be manually set at 100,000 gas;
 > otherwise the transaction will fail. Gas Price can be set to 0.06 gwei.
 

--- a/_rsk/rbtc/conversion/with-ledger.md
+++ b/_rsk/rbtc/conversion/with-ledger.md
@@ -197,7 +197,7 @@ Then do a transaction to the Bridge Contract.
 
 Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> Note: The minimum amount to send is 0.008 R-BTC for Mainnet
+> Note: The minimum amount to send must be greater than 0.008 R-BTC for Mainnet;
 > Gas Limit of the transaction needs to be manually set at 100,000 gas;
 > otherwise the transaction will fail.
 > Gas Price can be set to 0.06 gwei.


### PR DESCRIPTION
## What

- DevPortal shows wrongly the minimum peg out value (strict equal instead of greater than)

## Why

- Avoid people loosing their funds

