### PR TITLE
docs: add name validation rules, refs, and examples to RNS specs page

### DIFF
--- a/rif/rns/specs/index.md
+++ b/rif/rns/specs/index.md
@@ -13,14 +13,16 @@ When a user needs to type a domain name, the length of each label is omitted and
 
 ## Valid names
 
-A valid RNS domain is defined as follows:
+For simplicity, a valid RNS domain is defined as follows:
 
-- TLD is one of the predefined TLDs, which currently is only `rsk`
-- The first label is compulsory, and must be alphanumeric
-- Any second and subsequent labels are optional, and must be alphanumeric if present
-- All labels and and TLD are delimited by `.`
+- TLD is one of the predefined TLDs,
+  which currently may only be `rsk`
+- The first label is compulsory
+- Any second and subsequent labels are optional
+- All labels must be alphanumeric and lower case
+- All labels and the TLD are delimited by `.`
 
-The reference implementation for RNS validation can be found in `rns.js`
+The reference implementation for RNS domain validation can be found in `rns.js`
 
 - `AVAILABLE_TLDS` in [`src/constants.ts`](https://github.com/rnsdomains/rns-js/blob/master/src/constants.ts)
 - `isValidDomain` and `isValidLabel` in [`src/utils.ts`](https://github.com/rnsdomains/rns-js/blob/master/src/utils.ts)
@@ -28,20 +30,25 @@ The reference implementation for RNS validation can be found in `rns.js`
 Example #1: `uno2tres.rsk` is valid:
 
 - ✔️ TLD is `rsk`
-- ✔️ First label is `uno2tres`; which is present and alphanumeric
+- ✔️ First label is `uno2tres`;
+  which is present and lowercase alphanumeric
 - ✔️ Second and subsequent labels are not present
 
 Example #2: `rss.website.alice.rsk` is valid:
 
 - ✔️ TLD is `rsk`
-- ✔️ First label is `alice`; which is present and alphanumeric
-- ✔️ Second label is `website`; which is present and alphanumeric
-- ✔️ Third label is `rss`; which is present and alphanumeric
+- ✔️ First label is `alice`;
+  which is present and lowercase alphanumeric
+- ✔️ Second label is `website`;
+  which is present and lowercase alphanumeric
+- ✔️ Third label is `rss`;
+  which is present and lowercase alphanumeric
 
 Example #3: `my_illegal_domain.com` is invalid:
 
 - ❌ TLD is `com`
-- ❌ First label is `my_illegal_domain`; which is present, however contains non-alphanumeric characters
+- ❌ First label is `my_illegal_domain`;
+  which is present, however contains non-alphanumeric characters
 - ✔️ Second and subsequent labels are not present
 
 ## Name mapping convention

--- a/rif/rns/specs/index.md
+++ b/rif/rns/specs/index.md
@@ -2,15 +2,49 @@
 layout: rsk
 title: RNS Specs
 description: "RNS specifications, and name mapping convention"
+tags: rns
 ---
 
 The domain name space is a tree structure. Each node and leaf on the tree corresponds to a resource set (which may be empty). The domain system makes no distinctions between the uses of the interior nodes and leaves, and this memo uses the term "node" to refer to both.
 
 The domain name of a node is the list of the labels on the path from the node to the root of the tree.  By convention, the labels that compose a domain name are printed or read left to right, from the most specific (lowest, farthest from the root) to the least specific (highest, closest to the root).
 
-When a user needs to type a domain name, the length of each label is omitted and the labels are separated by dots (".").  Since a complete domain name ends with the root label, this leads to a printed form which ends in a dot, that is omitted. For example, a valid domain name is `wallet.alice.rsk`.
+When a user needs to type a domain name, the length of each label is omitted and the labels are separated by dots (`.`).  Since a complete domain name ends with the root label, this leads to a printed form which ends in a dot, that is omitted. For example, a valid domain name is `wallet.alice.rsk`.
 
-### Name mapping convention
+## Valid names
+
+A valid RNS domain is defined as follows:
+
+- TLD is one of the predefined TLDs, which currently is only `rsk`
+- The first label is compulsory, and must be alphanumeric
+- Any second and subsequent labels are optional, and must be alphanumeric if present
+- All labels and and TLD are delimited by `.`
+
+The reference implementation for RNS validation can be found in `rns.js`
+
+- `AVAILABLE_TLDS` in [`src/constants.ts`](https://github.com/rnsdomains/rns-js/blob/master/src/constants.ts)
+- `isValidDomain` and `isValidLabel` in [`src/utils.ts`](https://github.com/rnsdomains/rns-js/blob/master/src/utils.ts)
+
+Example #1: `uno2tres.rsk` is valid:
+
+- ✔️ TLD is `rsk`
+- ✔️ First label is `uno2tres`; which is present and alphanumeric
+- ✔️ Second and subsequent labels are not present
+
+Example #2: `rss.website.alice.rsk` is valid:
+
+- ✔️ TLD is `rsk`
+- ✔️ First label is `alice`; which is present and alphanumeric
+- ✔️ Second label is `website`; which is present and alphanumeric
+- ✔️ Third label is `rss`; which is present and alphanumeric
+
+Example #3: `my_illegal_domain.com` is invalid:
+
+- ❌ TLD is `com`
+- ❌ First label is `my_illegal_domain`; which is present, however contains non-alphanumeric characters
+- ✔️ Second and subsequent labels are not present
+
+## Name mapping convention
 
 Each domain name has a node identifier in the RNS Registry, that is obtained via `namehash` functions, that is as follows:
 
@@ -25,6 +59,7 @@ def namehash(name):
 
 Given a `node`, a `subnode` can be identified by using its label: `sha3(namehash(node) + sha3(label))`
 
-Further reading:
+## Further reading
+
 - [Registry specs](registry)
 - [Resolver specs](resolvers)


### PR DESCRIPTION
## What

- update the RNS specs page to include info about valid names
  - description of rules, links to reference implementation in rns.js, and examples

## Why

- presently, this is undocumented

## Refs

- Reference impl: `isValidDomain` and `isValidLabel` in [rns.js `src/utils.ts`](https://github.com/rnsdomains/rns-js/blob/master/src/utils.ts)
