### PR TITLE
docs: cli flags for rskj

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -81,6 +81,7 @@
               <a href="/rsk/node/configure/">Configure</a>
               <ul>
                   <li class="hide-mobile"><a href="/rsk/node/configure/">Configure</a></li>
+                  <li><a href="/rsk/node/configure/cli/">CLI</a></li>
                   <li><a href="/rsk/node/configure/reference/">Reference</a></li>
                   <li><a href="/rsk/node/configure/verbosity/">Verbosity</a></li>
                   <li><a href="/rsk/node/configure/switch-network/">Switch networks</a></li>

--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -32,7 +32,7 @@ When none of these are specified, RSK Mainnet is used by default.
 
 The RSK node stores transactions, blocks,
 and other blockchain state on disk.
-This is known as the *Block Database*.
+This is known as the *Blockchain Database*.
 
 - `--reset`:
   Indicates that the block database should be erased, and should start from scratch,

--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -1,0 +1,66 @@
+---
+layout: rsk
+title: Command Line Interface
+tags: rsk, rskj, node, cli
+description: "Command Line Interface for RSK"
+collection_order: 2405
+permalink: /rsk/node/configure/cli/
+render_features: 'custom-terminals'
+---
+
+Most of the configurable options or settings for RSKj are available
+in "config". See [config reference](../reference/) for more details.
+
+However, a small number of command line flags are also available:
+
+## Network related
+
+The following CLI flags determine which network the RSK node will connect to.
+
+- `--main`:
+  Indicates that the configuration for the RSK Mainnet (public network) should be used.
+- `--testnet`:
+  Indicates that the configuration for the RSK Testnet (public network) should be used.
+- `--regtest`:
+  Indicates that the configuration for the RSK Regtest (localhost network) should be used.
+
+Only one of these three CLI flags should be specified.
+
+When none of these are specified, RSK Mainnet is used by default.
+
+## Database related
+
+The RSK node stores transactions, blocks,
+and other blockchain state on disk.
+This is known as the *Block Database*.
+
+- `--reset`:
+  Indicates that the block database should be erased, and should start from scratch,
+  i.e. from genesis block.
+  This is typically expected to be used when connecting to RSK Regtest,
+  or in select debugging scenarios.
+- `--import`:
+  Indicates that the block database should be imported from an external source.
+  This is typically expected to be use when connecting to RSK Testnet or RSK Mainnet,
+  and when a reduction in "initial sync time" is desired.
+
+## Configuration related
+
+- `--verify-config`:
+  Indicates that the configuration file used by this run of the RSK node
+  should be validated.
+  By default this step is always performed.
+- `--print-system-info`:
+  Indicates that the system information of the computer that the RSK node
+  is running on should be output.
+  By default this is always output.
+- `--skip-java-check`:
+  Indicates that the detection of the version of
+  the Java Virtual Machine that the RSK node is running in is supported.
+  By default, this check is always performed, to ensure that the RSK node is running
+  in a compatible environment.
+
+## Reference implementation
+
+See the definition of the CLI flags in the RSKj codebase:
+[`NodeCliFlags` in `NodeCliFlags.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/config/NodeCliFlags.java)

--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -41,7 +41,7 @@ This is known as the *Block Database*.
   or in select debugging scenarios.
 - `--import`:
   Indicates that the block database should be imported from an external source.
-  This is typically expected to be use when connecting to RSK Testnet or RSK Mainnet,
+  This is typically expected to be used when connecting to RSK Testnet or RSK Mainnet,
   and when a reduction in "initial sync time" is desired.
 
 ## Configuration related
@@ -53,7 +53,7 @@ This is known as the *Block Database*.
 - `--print-system-info`:
   Indicates that the system information of the computer that the RSK node
   is running on should be output.
-  By default this is always output.
+  By default, this is always output.
 - `--skip-java-check`:
   Indicates that the detection of the version of
   the Java Virtual Machine that the RSK node is running in is supported.

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -8,6 +8,11 @@ permalink: /rsk/node/configure/
 render_features: 'custom-terminals'
 ---
 
+## Command Line Interface
+
+The RSK node can be started with different
+[CLI flags](./cli/).
+
 ## Setting your own config preferences
 
 It is a bit different if:

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -13,6 +13,11 @@ For advanced configuration requirements, please refer to this
 [expected configuration file](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/expected.conf).
 This contains all possible configuration fields parsed by RSKj.
 
+The default values for the config file are defined in this
+[reference config file](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf);
+and are "inherited" and varied based on the
+[selected network](https://github.com/rsksmart/rskj/tree/master/rskj-core/src/main/resources/config).
+
 ## Guide
 
 The following detail the most commonly used configuration fields parsed by RSKj.


### PR DESCRIPTION
## What

- Descriptions of the RSKj CLI flags
- Add links for base config with default values

## Why

- This is presently undocumented

## Refs

- [`NodeCliFlags.java` in rskj](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/config/NodeCliFlags.java)
- [rskj PR #1432](https://github.com/rsksmart/rskj/pull/1432/)
- [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf)
