### PR TITLE
Hide rLogin integration links

### DIFF
--- a/_includes/rif-id/rlogin-integrate.html
+++ b/_includes/rif-id/rlogin-integrate.html
@@ -1,3 +1,4 @@
+<!--
 <div class="container the-stack">
   <div class="row rif_blue_text">
     <div class="col">
@@ -26,3 +27,4 @@
     </div>
   </div>
 </div>
+-->


### PR DESCRIPTION
## What

- Hides rLogin integration links

## Why

- The articles are not yet complete
