### PR TITLE
feat: add redirect page for open slack invite

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -54,7 +54,7 @@
                 Community
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="https://join.slack.com/t/open-rsk-dev/shared_invite/zt-m0pbuyia-QW~WEI27Ag3Do7qWEjW41w">Slack</a>
+                <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="/slack/">Slack</a>
                 <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="https://github.com/rsksmart">GitHub</a>
                 <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="https://research.rsk.dev/">Forum</a>
                 <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="https://fund.rsk.co/">Ecosystem Fund</a>

--- a/slack.md
+++ b/slack.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /slack/
+redirect: https://join.slack.com/t/open-rsk-dev/shared_invite/zt-m0pbuyia-QW~WEI27Ag3Do7qWEjW41w
+---


### PR DESCRIPTION
## What

- `developers.rsk.co/slack` --> slack invite link
- update existing links within devportal top use this instead

## Why

- easier to maintain
- tweets etc do not get outdated links (that 404)
- bonus: human readable/ memorable link

## Refs

- #EC-70
