### PR TITLE
Add default endpoint as reference

### DIFF
--- a/_rsk/node/architecture/json-rpc.md
+++ b/_rsk/node/architecture/json-rpc.md
@@ -12,9 +12,68 @@ RSK currently supports the following:
 - [Management API methods](#management-api-methods)
 - [RPC PUB SUB methods](#rpc-pub-sub-methods)
 
-> Note: request headers must contain the specification of ``` "Content-Type:application/json" ```
+## Transport protocols
+
+### HTTP transport protocol
+
+HTTP requests should be made:
+
+- to the port number specified in the config for `rpc.providers.web.http.port`
+  - this is `4444` by default
+  - for [public nodes](/rsk/public-nodes/), omit the port number
+- to the "root" route (`/`)
+- using the HTTP verb `POST`
+- specifying a `Content-Type` header of `application/json`
+- with a request body specified as stringified JSON
+
+For example, a `curl` command to a `localhost` RSK node
+would look similar to this:
+
+```shell
+curl http://localhost:4444/ \ \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"RPC_METHOD_NAME","params":[RPC_REQUEST_PARAMETERS],"id":1}'
+
+```
+
+### WebSockets transport protocol
+
+WebSockets connections should be established:
+
+- to the port number specified in the config for `rpc.providers.web.ws.port`
+  - this is `4445` by default
+  - [public nodes](/rsk/public-nodes/) do **not** have the WebSockets transport protocol enabled
+- to the WebSockets route (`/websocket`)
+
+Once connected:
+
+- Send a request body specified as stringified JSON
+- No "verb" or "headers" are necessary, as these are specific to the HTTP transport protocol
+
+For example, a `wscat` command to connect to a `localhost` RSK node
+would look similar to this:
+
+```shell
+wscat -c ws://localhost:4445/websocket
+```
+
+After the connection has been established using `wscat`,
+you may send multiple RPC requests within the same session.
+(Note that `> ` marks requests to be input,
+and that `< ` marks responses that will be printed.)
+
+```json
+> {"jsonrpc":"2.0","method":"RPC_METHOD_NAME","params":[RPC_REQUEST_PARAMETERS],"id":1}
+< {"jsonrpc":"2.0","id":1,"result":"RPC_RESPONSE"}
+
+> {"jsonrpc":"2.0","method":"RPC_METHOD_NAME","params":[RPC_REQUEST_PARAMETERS],"id":2}
+< {"jsonrpc":"2.0","id":2,"result":"RPC_RESPONSE"}
+```
 
 ## JSON RPC methods
+
+### JSON RPC supported
 
 | Method | Supported | Comments |
 | ------ | ------ | ------ |

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -224,6 +224,8 @@ Describes the configuration for the RPC protocol.
     * `rpc.providers.web.ws.bind_address = address`
       is the WS-RPC server listening interface.
       By default RSK uses `localhost`.
+
+    **NOTE**: in order to use websockets functionality, suffix `websocket` must be added to the endpoint. Example: `ws://localhost:4445/websocket`.
 * `rpc.modules` lists of different RPC modules.
   If a module is not in the list and enabled,
   its RPC calls are discarded.

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -213,6 +213,8 @@ Describes the configuration for the RPC protocol.
     * `rpc.providers.web.http.hosts = []`
       is the list of node's domain names or IPs.
       Check [restrictions on valid host names](https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names).
+    * **NOTE**: For details on how to connect over HTTP,
+      see [HTTP Transport Protocol](/rsk/node/architecture/json-rpc/#http-transport-protocol "RSK JSON-RPC - HTTP").
   * `rpc.providers.web.ws`
     defines WebSocket configuration:
     * `rpc.providers.web.ws.enabled = [true/false]`
@@ -224,8 +226,8 @@ Describes the configuration for the RPC protocol.
     * `rpc.providers.web.ws.bind_address = address`
       is the WS-RPC server listening interface.
       By default RSK uses `localhost`.
-
-    **NOTE**: in order to use websockets functionality, suffix `websocket` must be added to the endpoint. Example: `ws://localhost:4445/websocket`.
+    * **NOTE**: For details on how to connect over WebSockets,
+      see [Websockets Transport Protocol](/rsk/node/architecture/json-rpc/#websockets-transport-protocol "RSK JSON-RPC - WebSockets").
 * `rpc.modules` lists of different RPC modules.
   If a module is not in the list and enabled,
   its RPC calls are discarded.


### PR DESCRIPTION
## What

- Add note about `websocket` suffix and the default endpoint for websockets

## Why

- Not clear at all how to use this feature