### PR TITLE
adds testnet contracts and Pinning basic info

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -417,6 +417,14 @@
                   </li>
                 </ul>
               </li>
+              <li>
+                <span class="fa fa-chevron-right"></span>
+                <a href="/rif/storage/pinning/">Pinning Service</a>
+                <ul>
+                  <li><a href="/rif/storage/pinning/">About</a></li>
+                  <li><a href="/rif/storage/pinning/local_cli">Run local using CLI</a></li>
+                </ul>
+              </li>
             </ul>
           </li>
           <li>

--- a/rif/marketplace/testnet.md
+++ b/rif/marketplace/testnet.md
@@ -25,6 +25,16 @@ NFTS ProxyAdmin:  [`0xE660A209c733ba0C1331E9997cb31309e7c28A52`](https://explore
 
 NFTS Implementation:  [`0xcEd09738227b611b4681a1Aa05CDb0D72ebFbEA5`](https://explorer.testnet.rsk.co/address/0xced09738227b611b4681a1aa05cdb0d72ebfbea5)
 
+### Storage Services - Manager
+Storage Proxy: [`0x839856c0ec1aa2AED25d47Fd3DDb7a14DAC3e76d`](https://explorer.testnet.rsk.co/address/0x839856c0ec1aa2aed25d47fd3ddb7a14dac3e76d)
+
+Storage ProxyAdmin:  [`0xB0Ec8d94d53b336Eca5b7280a52Ce3D241C98e11`](https://explorer.testnet.rsk.co/address/0xb0ec8d94d53b336eca5b7280a52ce3d241c98e11)
+
+Storage Implementation:  [`0xFAd0FDd942a5330594E7BBA270460EF8fA8579eC`](https://explorer.testnet.rsk.co/address/0xfad0fdd942a5330594e7bba270460ef8fa8579ec)
+
+###  Staking (Storage)
+Staking: [`0x11Be792f8fcfc84897b88E149dD3Fb66B422256f`](https://explorer.testnet.rsk.co/address/0x11be792f8fcfc84897b88e149dd3fb66b422256f)
+
 
 ## RNS Manager (to register and manage RNS Domains)
 

--- a/rif/storage/pinning/index.md
+++ b/rif/storage/pinning/index.md
@@ -1,0 +1,15 @@
+---
+layout: rsk
+title: RIF Storage Pinning service
+---
+
+## RIF Storage Pinning service
+The RIF Storage Pinning service, offered together with the RIF Marketplace, is a service that allows Storage Providers to list their offers and enter in storage agreements with consumers, which can pay in different methods such as R-BTC or RIF tokens.
+
+## Repositories
+ - [Pinning Service](https://github.com/rsksmart/rif-storage-pinner): A nodejs service which listens on Providers offer and pins/unpins files from Provider run IPFS node
+ - [Storage Smart Contracts](https://github.com/rsksmart/rif-marketplace-storage): A smart contract registry which stores the offers and agreements.
+ - [Pinning CLI](https://github.com/rsksmart/rif-storage-cli): CLI tool for interacting with the Storage Smart Contracts
+ - [Pinning UI](https://github.com/rsksmart/rif-storage-pinning-ui): Simple UI for development purposes which interacts with the Storage Smart Contracts
+
+Additional information for the Pinning service can be found in [RIF Marketplace-Services-Storage](/rif/marketplace/services/storage/techspecs)

--- a/rif/storage/pinning/local_cli.md
+++ b/rif/storage/pinning/local_cli.md
@@ -1,0 +1,28 @@
+---
+layout: rsk
+title: RIF Storage Pinning service - Local setup with storage dev CLI
+---
+
+This guide is quite advanced and assumes a greater knowledge of how to setup local blockchain environment, IFPS, etc. 
+
+## Repositories
+
+ - Storage Smart Contracts: [github.com/rsksmart/rif-marketplace-storage](https://github.com/rsksmart/rif-marketplace-storage)
+ - Storage Development CLI: [github.com/rsksmart/rif-storage-cli](https://github.com/rsksmart/rif-storage-cli)
+
+## Steps
+
+ 1. Clone all repos, run `npm install` everywhere.
+ 1. Start up Ganache
+ 1. In Smart Contracts repo using `truffle deploy` deploy contracts and note the `StorageManager` contract address.
+ 1. Go to Storage Development CLI and create an Offer for the given contract address (use the `npm run bin` script)
+ 1. Go to Pinning Service repo and configure to use it the deployed contract. You can use environment variables, `local.json` or CLI parameters for this.
+ 1. Run `npm run init` - this will bootstrap IPFS repos in `.repos` folder and configure the ports settings.
+ 1. In one tab run `npm run ipfs:consumer daemon`
+ 1. In another tab run `npm run ipfs:provider daemon`
+ 1. Create Offer. Suggested way is using the Storage Development CLI. Use `npm run bin` and don't forget to configure the correct contract address.
+    Note the Offer ID (which is the address of your RSK account from which you have created the Offer)
+ 1. Run `npm run bin -- --offerId <offerId>` to start the service.
+
+Consumer IPFS API runs on `5002`.
+Provider IPFS API runs on `5003`.


### PR DESCRIPTION
## What

- Reference to Storage contracts in Testnet
- Section in RIF Storage about Pinning

## Why

- It is important to include the contracts addresses which are already deployed.