### PR TITLE
Peg out extra note about minimum amount

### DIFF
--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -82,7 +82,7 @@ You can get a corresponding BTC address from your R-BTC private key by using [gi
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> **Importante note**: The minimum amount to send must be **greater than** 0.008 R-BTC for Mainnet (sending the exact amount fails and funds get lost);
+> **Important note**: The minimum amount to send must be **greater than** 0.008 R-BTC for Mainnet (sending the exact amount fails and funds get lost);
 > Gas Limit of the transaction needs to be manually set at 100,000 gas;
 > otherwise the transaction will fail. Gas Price can be set to 0.06 gwei.
 

--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -82,7 +82,7 @@ You can get a corresponding BTC address from your R-BTC private key by using [gi
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> Note: The minimum amount to send must be greater than 0.008 R-BTC for Mainnet;
+> **Importante note**: The minimum amount to send must be **greater than** 0.008 R-BTC for Mainnet (sending the exact amount fails and funds get lost);
 > Gas Limit of the transaction needs to be manually set at 100,000 gas;
 > otherwise the transaction will fail. Gas Price can be set to 0.06 gwei.
 


### PR DESCRIPTION
## What

- Adding peg out extra note about minimum amount

## Why

- Users keep sending exact amount and losing funds
