### PR TITLE
Update testnet pegout guide to avoid user errors

### DIFF
--- a/_rsk/rbtc/conversion/networks/testnet.md
+++ b/_rsk/rbtc/conversion/networks/testnet.md
@@ -88,7 +88,7 @@ You can get a corresponding tBTC address from your tR-BTC private key by using [
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> **Importante note**: The minimum amount to send must be **greater than** 0.005 tR-BTC for Testnet (sending the exact amount fails and funds get lost)
+> **Important note**: The minimum amount to send must be **greater than** 0.005 tR-BTC for Testnet (sending the exact amount fails and funds get lost)
 
 Gas Limit of the transaction needs to be manually set at 100,000 gas;
 otherwise the transaction will fail.

--- a/_rsk/rbtc/conversion/networks/testnet.md
+++ b/_rsk/rbtc/conversion/networks/testnet.md
@@ -88,7 +88,7 @@ You can get a corresponding tBTC address from your tR-BTC private key by using [
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> Note: The minimum amount to send is 0.005 tR-BTC for Testnet
+> **Importante note**: The minimum amount to send must be **greater than** 0.005 tR-BTC for Testnet (sending the exact amount fails and funds get lost)
 
 Gas Limit of the transaction needs to be manually set at 100,000 gas;
 otherwise the transaction will fail.


### PR DESCRIPTION
## What

- Update testnet guide for pegouts, indicating value needs to be above minimum

## Why

- Prone to user errors

