### PR TITLE
DevPortal: Added Hackernoon URL to rLogin Guide

### DIFF
--- a/guides/rlogin/connect-frontend.md
+++ b/guides/rlogin/connect-frontend.md
@@ -258,10 +258,12 @@ this will be covered in the following article.
 
 ## Useful links
 
+* [rLogin: The New Authentication Libraries for Blockchain Based Apps on Hackernoon](https://hackernoon.com/rlogin-the-new-authentication-libraries-for-blockchain-based-apps-h619330z)
 * [RIF Identity docs](https://developers.rsk.co/rif/identity/)
 * [rLogin repo](https://github.com/rsksmart/rlogin)
 * [rLogin docs](https://developers.rsk.co/rif/identity/rlogin/)
 * [rLogin sample apps](https://github.com/rsksmart/rlogin-sample-apps)
 * [`web3modal`](https://github.com/web3Modal/web3modal/)
 * [EIP-1193 - Ethereum Provider JavaScript API](https://eips.ethereum.org/EIPS/eip-1193)
-* [RIF landing](https://rifos.org)
+* [RIF Website](https://rifos.org)
+


### PR DESCRIPTION
## What

- Added Hackernoon URL to rLogin Guide

## Why

- Link rLogin guide on DevPortal to existing hackernoon article

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-95?atlOrigin=eyJpIjoiNDI0ODY2MjRlOGMwNDM4Y2JlYTFkMTllOGZiNWFkMzEiLCJwIjoiaiJ9)
