### PR TITLE
DevPortal: Updated content to remove version numbers from public node endpoints

### DIFF
--- a/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
+++ b/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
@@ -40,12 +40,12 @@ npm install
 Enter the following command into terminal, to get the current gas-price for both Testnet and Mainnet, and a [Mnemonic](https://en.bitcoinwiki.org/wiki/Mnemonic_phrase) phrase: 
 
 ```terminal
-curl https://public-node.testnet.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .testnet.gas-price.json
+curl https://public-node.testnet.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .testnet.gas-price.json
 ```
 and;
 
 ```terminal
-curl https://public-node.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .mainnet.gas-price.json
+curl https://public-node.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .mainnet.gas-price.json
 ```
 
 and;
@@ -721,7 +721,7 @@ networks: {
     testnet: {
       provider: () => new HDWalletProvider(
         testnetSeedPhrase,
-        'https://public-node.testnet.rsk.co/2.0.1/',
+        'https://public-node.testnet.rsk.co/',
       ),
       // Ref: http://developers.rsk.co/rsk/architecture/account-based/#chainid
       network_id: 31,
@@ -756,7 +756,7 @@ and save it to `.testnet.gas-price.json`,
 using the following command:
 
 ```terminal
-curl https://public-node.testnet.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .testnet.gas-price.json
+curl https://public-node.testnet.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .testnet.gas-price.json
 ```
 
 > A file named `.testnet.gas-price.json` previously generated will be updated if there are any changes in gas price. You can locate the file at the root folder. 

--- a/tutorials/deploy-smart-contracts.md
+++ b/tutorials/deploy-smart-contracts.md
@@ -354,7 +354,7 @@ Get the current gas price of the testnet network, and save to .gas-price-testnet
 In your project folder, run this cURL command:
 
 ```terminal
-curl https://public-node.testnet.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .gas-price-testnet.json
+curl https://public-node.testnet.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .gas-price-testnet.json
 ```
 
 You should receive a response similar to the following in the file:
@@ -381,7 +381,7 @@ In the `truffle-config.js` file, include this configuration at network section:
 
 ```javascript
 testnet: {
-      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: Math.floor(gasPriceTestnet * 1.1),
       networkCheckTimeout: 1e9
@@ -415,7 +415,7 @@ module.exports = {
       network_id: "*"
     },
     testnet: {
-      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: Math.floor(gasPriceTestnet * 1.1),
       networkCheckTimeout: 1e9

--- a/tutorials/ethereum-devs/setup-truffle-oz.md
+++ b/tutorials/ethereum-devs/setup-truffle-oz.md
@@ -312,7 +312,7 @@ In addition to using the local node, we want to publish smart contracts to the t
 This is an example using cURL. Enter the following command into your terminal.
 
 ```shell
-curl https://public-node.testnet.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+curl https://public-node.testnet.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```
 
 This is a very simple query that simply asks what the latest block number is.
@@ -571,7 +571,7 @@ Get the current gas price of the testnet network, and save to `.gas-price-testne
 In your project folder, run this cURL command:
 
 ```shell
-curl https://public-node.testnet.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .gas-price-testnet.json
+curl https://public-node.testnet.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .gas-price-testnet.json
 ```
 
 ![gas price result](/assets/img/tutorials/setup-truffle-oz/image-25.png)
@@ -603,7 +603,7 @@ In the `truffle-config.js` file, include this configuration at `network` section
 
 ```javascript
     testnet: {
-      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: Math.floor(gasPriceTestnet * 1.1),
       networkCheckTimeout: 1e9
@@ -638,7 +638,7 @@ module.exports = {
       network_id: "*"
     },
     testnet: {
-      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: Math.floor(gasPriceTestnet * 1.1),
       networkCheckTimeout: 1e9

--- a/tutorials/quiz-app-to-dapp.md
+++ b/tutorials/quiz-app-to-dapp.md
@@ -386,7 +386,7 @@ truffle compile
 Get and save the gas price from `testnet`:
 
 ```bash
-$ curl https://public-node.testnet.rsk.co/2.0.1/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .gas-price-testnet.json
+$ curl https://public-node.testnet.rsk.co/ -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' > .gas-price-testnet.json
 
 $ ls -al
 ```
@@ -444,7 +444,7 @@ In the same `truffle-config.js` in the `networks` section, add the testnet confi
 
 ```javascript
 testnet: {
-      provider: () => new HDWalletProvider(A_MNEMONIC, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(A_MNEMONIC, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: Math.floor(gasPriceTestnet * 1.1),
       networkCheckTimeout: 1e9

--- a/tutorials/tokens/create-a-collectable-token.md
+++ b/tutorials/tokens/create-a-collectable-token.md
@@ -211,7 +211,7 @@ const path = require("path");
 module.exports = {
   networks: {
     testnet: {
-      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: Math.floor(gasPriceTestnet * 1.1),
       networkCheckTimeout: 1e9

--- a/tutorials/tokens/create-a-token.md
+++ b/tutorials/tokens/create-a-token.md
@@ -187,7 +187,7 @@ If you are using a Windows OS, I suggest to use the Git Bash terminal.
 Download the installer from the [Git official site](https://git-scm.com/).
 
 ```shell
-curl https://public-node.testnet.rsk.co/2.0.1/ \
+curl https://public-node.testnet.rsk.co/ \
   -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```
@@ -256,7 +256,7 @@ const mnemonic = fs.readFileSync(".secret").toString().trim();
 module.exports = {
   networks: {
     testnet: {
-      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/2.0.1/'),
+      provider: () => new HDWalletProvider(mnemonic, 'https://public-node.testnet.rsk.co/'),
       network_id: 31,
       gasPrice: 0x387EE40,
       networkCheckTimeout: 1000000000

--- a/tutorials/truffle-boxes/pet-shop-box.md
+++ b/tutorials/truffle-boxes/pet-shop-box.md
@@ -343,7 +343,7 @@ Get the current gas price of the network, and save to `.gas-price.json`.
 
 ```shell
 curl \
-  https://public-node.testnet.rsk.co/2.0.1/ \
+  https://public-node.testnet.rsk.co/ \
   -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' \
   > .gas-price-testnet.json
@@ -417,7 +417,7 @@ The effect that this has is to get a slightly higher priority for our transactio
     testnet: {
       provider: () => new HDWalletProvider(
         mnemonic,
-        'https://public-node.testnet.rsk.co/2.0.1/',
+        'https://public-node.testnet.rsk.co/',
       ),
       network_id: 31,
       gasPrice: gasPriceTestnet + 1e6,

--- a/tutorials/workshop-prereqs.md
+++ b/tutorials/workshop-prereqs.md
@@ -213,7 +213,7 @@ THe latter option requires no setup, and that is what we'll be doing:
 
 ```shell
 curl \
-  https://public-node.testnet.rsk.co/2.0.1/ \
+  https://public-node.testnet.rsk.co/ \
   -s -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 


### PR DESCRIPTION
## What

- Updated content to remove version numbers from public node endpoints

## Why

- version numbers are used to connect to particular version numbers of rskj
- particular versions have recently been deprecated

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-100?atlOrigin=eyJpIjoiZWJmN2NlZWEzODgxNGQ1YzkzYzU1ODVhNTc5YWUyN2MiLCJwIjoiaiJ9)
