### PR TITLE
docs: specify the RBTC conversion minimum amount to 8 decimal places

### DIFF
--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -85,9 +85,14 @@ RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 <div class="fade alert alert-warning show">
   <strong>Important note</strong>:
   The minimum amount to send must be
-  <strong>greater than</strong>
-  0.008 R-BTC for Mainnet (sending the exact amount fails and funds get lost);
-Gas Limit of the transaction needs to be manually set at 100,000 gas; otherwise the transaction will fail. Gas Price can be set to 0.06 gwei (or the gas price suggested by the wallet).
+  <strong>at least 0.00800001 R-BTC</strong>
+  for Mainnet
+  Sending any lower amount fails and
+  <strong>funds will be lost</strong>.
+  The Gas Limit of the transaction needs to be manually set at 100,000 gas;
+  otherwise the transaction will fail.
+  Gas Price can be set to 0.06 gwei
+  (or the gas price suggested by the wallet).
 </div>
 
 ![Customize Gas in Metamask before send transaction on RSK](/dist/images/metamask-gas-limit.png)


### PR DESCRIPTION
## What

- by stating an explicit minimum figure, interpretation or copy-paste based errors are avoided

## Why

- previously, both "at least" and "more than" have been incorrectly interpreted
  as `>=` (instead of `>` which is what was intended)

## Refs

- Related: [#555](https://github.com/rsksmart/devportal/pull/555)
