### PR TITLE
Chore: updated CLI flags and config options pages to add new flags and link to each other

### DIFF
--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -11,7 +11,7 @@ render_features: 'custom-terminals'
 Most of the configurable options or settings for RSKj are available
 in "config". See [config reference](../reference/) for more details.
 
-However, a small number of command line flags are also available:
+However, a list of command line flags are also available:
 
 ## Network related
 
@@ -59,6 +59,8 @@ This is known as the *Blockchain Database*.
   the Java Virtual Machine that the RSK node is running in is supported.
   By default, this check is always performed, to ensure that the RSK node is running
   in a compatible environment.
+- `-base-path`: 
+  Specifies the base path `NodeCliOption` to enhance the block replay tool user experience.
 
 ## Reference implementation
 

--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -59,8 +59,8 @@ This is known as the *Blockchain Database*.
   the Java Virtual Machine that the RSK node is running in is supported.
   By default, this check is always performed, to ensure that the RSK node is running
   in a compatible environment.
-- `-base-path`: 
-  Specifies the base path `NodeCliOption` to enhance the block replay tool user experience.
+- `--base-path`: 
+  Specifies the the value of `database.dir`, where the blockchain database is stored.
 
 ## Reference implementation
 

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -7,6 +7,8 @@ collection_order: 2410
 render_features: 'tables-with-borders'
 ---
 
+See [CLI flags](../cli/) for command line flag options.
+
 ## Advanced Configuration
 
 For advanced configuration requirements, please refer to this


### PR DESCRIPTION
## What

- Updated CLI flags and config options pages to add new flags and link to each other

## Why

- It's easier to find info - a reader on one of these pages is likely to also want to know info that is on the other page too.

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-110?atlOrigin=eyJpIjoiOWUyYTk3YWYzNWQyNDI2YjhlMGFlOWM5ZmFjODNiYmUiLCJwIjoiaiJ9)
