### PR TITLE
Chore: Replaced Webinars Link with RSK❤️Gitcoin Hackathon Link

### DIFF
--- a/_includes/before-content.html
+++ b/_includes/before-content.html
@@ -1,5 +1,5 @@
 <div class="alert alert-info" role="alert">
-    <a href="/webinars?utm_source=devportal&utm_medium=infobar&utm_campaign=webinars" style="color: black!important;text-decoration: underline;">
-        Join our Webinars! Now you can watch and learn more about Blockchain!
+    <a href="https://gitcoin.co/hackathon/rsk-hack/onboard" style="color: black!important;text-decoration: underline;">
+        RSK Gitcoin Hackathon: 17 bounties, 25K in prizes, Join now!
     </a>
 </div>


### PR DESCRIPTION
## What

- Replaced Webinars Link with RSK❤️Gitcoin Hackathon Link

## Why

- Announce the RSK-Gitcoin hackathon on DevPortal
- Developers need to be aware of the hackathon

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-115?atlOrigin=eyJpIjoiYzZlOWJkYzEyMmZiNDJkZmJlMTg5MDhiNmZkYmY2NjQiLCJwIjoiaiJ9)
