### PR TITLE
Chore: Changed RWallet Android Link

### DIFF
--- a/wallet/rwallet/index.md
+++ b/wallet/rwallet/index.md
@@ -11,7 +11,7 @@ rWallet is an open-source easy to use blockchain wallet. It is the code-base to 
 
 <a href="http://github.com/rsksmart/rwallet" target="_blank" class="green-button">Start building</a>
 
-<a href="https://play.google.com/store/apps/details?id=com.rsk.rwallet.reactnative" target="blank"><img src="/assets/img/rwallet/android/google-play-badge.png" style="width: 160px; margin:0; padding:0;"></a><a href="https://apps.apple.com/us/app/id1489241342" target="blank"><img src="/assets/img/rwallet/ios/app-store-badge.svg" style="width: 145px; margin:0; padding:0;"></a>
+<a href="https://play.google.com/store/apps/details?id=com.rsk.rwallet.v2" target="blank"><img src="/assets/img/rwallet/android/google-play-badge.png" style="width: 160px; margin:0; padding:0;"></a><a href="https://apps.apple.com/us/app/id1489241342" target="blank"><img src="/assets/img/rwallet/ios/app-store-badge.svg" style="width: 145px; margin:0; padding:0;"></a>
 
 ## rWallet Architecture
 


### PR DESCRIPTION
## What

- Changed RWallet Android Link from https://play.google.com/store/apps/details?id=com.rsk.rwallet.reactnative
to: https://play.google.com/store/apps/details?id=com.rsk.rwallet.v2

## Why

- new app published under new name

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-116?atlOrigin=eyJpIjoiZWI4ZjJkZDhmZmY1NGNmM2E0YWFlOTVhODhhZGU3NjMiLCJwIjoiaiJ9)
