### PR TITLE
587+590 doctuto quick start command line for

### DIFF
--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -134,8 +134,8 @@ on how to do this.
 
 To run the node:
 
-```bash
-java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
+```shell
+java -classpath <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
 
 ```
 
@@ -144,7 +144,7 @@ java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.providers.web.
 > Example:
 >
 > ```windows-command-prompt
-> C:\>java -jar C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
+> C:\>java -classpath C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
 >
 > ```
 

--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -134,7 +134,7 @@ on how to do this.
 
 To run the node:
 
-```shell
+```bash
 java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regtest
 
 ```
@@ -144,7 +144,7 @@ java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regte
 > Example:
 >
 > ```windows-command-prompt
-> C:\>java -cp C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+> C:\>java -jar C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
 >
 > ```
 

--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -135,7 +135,7 @@ on how to do this.
 To run the node:
 
 ```shell
-java -cp <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regtest
 
 ```
 

--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -59,13 +59,13 @@ source "$HOME/.sdkman/bin/sdkman-init.sh"
 sdk list java  | grep "8\." # copy a selection for use below
 
 # install the version of java copied above
-# (replace accordingly)
-sdk install java 8.0.242.j9-adpt
+# (replace accordingly, at writing time this is 292)
+sdk install java 8.0.292.j9-adpt
 
 # show installed versions, and switch to the selected one
 # (replace accordingly)
 sdk list java | grep installed
-sdk use java 8.0.242.j9-adpt
+sdk use java 8.0.292.j9-adpt
 java -version
 
 ```

--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -135,7 +135,7 @@ on how to do this.
 To run the node:
 
 ```bash
-java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
 
 ```
 
@@ -144,7 +144,7 @@ java -jar <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regte
 > Example:
 >
 > ```windows-command-prompt
-> C:\>java -jar C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+> C:\>java -jar C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
 >
 > ```
 


### PR DESCRIPTION
## What
- Some discrepancies between tuto java options and actual jdk java option (also update version)
- No websocket server launched with the command

## Why

- The second example (websocket) do not run
- The change allow to run websocket server with RSKj
- This should not puzzled experienced users but some newbie with java could fill this as a showstopper

## Refs

- https://developers.rsk.co/quick-start/step1-install-rsk-local-node/
- https://github.com/rsksmart/rskj/blob/8ed73b15cb3060207741b34381371a563dda41d9/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java#L82
- https://github.com/rsksmart/rskj/blob/8ed73b15cb3060207741b34381371a563dda41d9/rskj-core/src/main/java/co/rsk/RskContext.java#L849
