### PR TITLE
Chore: Replaced RSK-Gitcoin Hackathon Link with the Webinar Link

### DIFF
--- a/_includes/before-content.html
+++ b/_includes/before-content.html
@@ -1,5 +1,5 @@
 <div class="alert alert-info" role="alert">
-    <a href="https://gitcoin.co/hackathon/rsk-hack/onboard" style="color: black!important;text-decoration: underline;">
-        RSK Gitcoin Hackathon: 17 bounties, 25K in prizes, Join now!
+    <a href="/webinars?utm_source=devportal&utm_medium=infobar&utm_campaign=webinars" style="color: black!important;text-decoration: underline;">
+        Join our Webinars! Now you can watch and learn more about Blockchain!
     </a>
 </div>


### PR DESCRIPTION
## What

- Replaced RSK-Gitcoin Hackathon Link with the Webinar Link

## Why

- Docs maintenance
- Hackathon ended

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-123?atlOrigin=eyJpIjoiYzhjN2NhOTJmNDU0NGVkMjg1NmM3MzIwZTMyMGNkMzAiLCJwIjoiaiJ9)
