### PR TITLE
Chore: Replaced Webinar link with link to RSK Open Slack

### DIFF
--- a/_includes/before-content.html
+++ b/_includes/before-content.html
@@ -1,5 +1,5 @@
 <div class="alert alert-info" role="alert">
-    <a href="/webinars?utm_source=devportal&utm_medium=infobar&utm_campaign=webinars" style="color: black!important;text-decoration: underline;">
-        Join our Webinars! Now you can watch and learn more about Blockchain!
+    <a href="/slack/" style="color: black!important;text-decoration: underline;">
+        Join our Open Slack Community to get the latest updates from the RSK Ecosystem!
     </a>
 </div>


### PR DESCRIPTION
## What

-  Replaced Webinar link with a link to RSK Open Slack

## Why

- Better CTA

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-127?atlOrigin=eyJpIjoiZGFkYTQ2OTk3Y2E4NDJmZTg0YWJiM2QwNzBmZTVlMDgiLCJwIjoiaiJ9)
