### PR TITLE
feat: rsk token bridge self service support

### DIFF
--- a/_quick-start/step2-install-truffle-and-ganache.md
+++ b/_quick-start/step2-install-truffle-and-ganache.md
@@ -8,7 +8,7 @@ collection_order: 20
 
 # Step 2 : Install Truffle and Ganache
 
-What we achieved in step 1 was to launch a local RSKj node on a Regtest network. 
+What we achieved in step 1 was to launch a local RSKj node on a Regtest network.
 Be sure to keep it running because instead of issuing manual JSON-RPC requests,
 we are now going to use some a more advanced developer tool,
 the [Truffle Suite](https://www.trufflesuite.com/).

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1740,6 +1740,18 @@ img {
   border-bottom: 1px solid #dedede;
 }
 
+/* rsk token bridge support */
+
+.rsk-token-bridge-support-input-area {
+  margin: 2em 0.5em 2em 0.5em;
+}
+
+.rsk-token-bridge-support-input-area input,
+.rsk-token-bridge-support-input-area select {
+  min-width: 80%;
+  margin-bottom: 0.5em;
+}
+
 /* Powpeg verifier check */
 
 .pegin-address-verifier {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -362,8 +362,7 @@ function renderRskTokenBridgeSupport() {
 }
 
 function onRskTokenBridgeSupportCheckButtonClicked() {
-  // const selfServiceSupportBaseUrl = 'http://localhost:11375';
-  const selfServiceSupportBaseUrl = 'https://self-service-support.vercel.app';
+  const selfServiceSupportBaseUrl = 'https://self-service.rsk.co';
   const txHash = document.querySelector('#rsk-token-bridge-support-txHash').value;
   const fromNetwork = document.querySelector('#rsk-token-bridge-support-fromNetwork').value;
   const walletName = document.querySelector('#rsk-token-bridge-support-walletName').value;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -339,10 +339,12 @@ function renderEquation(el) {
 // render feature: Rsk Token Bridge Support
 
 function renderRskTokenBridgeSupportSetup() {
-  // <script defer src="https://unpkg.com/axios/dist/axios.min.js"></script>
+  // <script src="https://cdn.jsdelivr.net/npm/axios@0.21.1/dist/axios.min.js" integrity="sha256-JLmknTdUZeZZ267LP9qB+/DT7tvxOOKctSKeUC2KT6E=" crossorigin="anonymous"></script>
   const scriptEl = document.createElement('script');
   scriptEl.setAttribute('defer', 'defer');
-  scriptEl.setAttribute('src', 'https://unpkg.com/axios/dist/axios.min.js');
+  scriptEl.setAttribute('integrity', 'sha256-JLmknTdUZeZZ267LP9qB+/DT7tvxOOKctSKeUC2KT6E=');
+  scriptEl.setAttribute('crossorigin', 'anonymous');
+  scriptEl.setAttribute('src', 'https://cdn.jsdelivr.net/npm/axios@0.21.1/dist/axios.min.js');
   scriptEl.setAttribute('onload', 'renderRskTokenBridgeSupport();');
   document.body.appendChild(scriptEl);
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -339,6 +339,13 @@ function renderEquation(el) {
 // render feature: Rsk Token Bridge Support
 
 function renderRskTokenBridgeSupportSetup() {
+  // <script src="https://cdn.jsdelivr.net/npm/markdown-it@12.0.6/dist/markdown-it.js" integrity="sha256-/MFRLGofgwznc7HHZUDrZc092i65/yOFgHEdGI7qCDQ=" crossorigin="anonymous"></script>
+  const scriptEl2 = document.createElement('script');
+  scriptEl2.setAttribute('defer', 'defer');
+  scriptEl2.setAttribute('integrity', 'sha256-/MFRLGofgwznc7HHZUDrZc092i65/yOFgHEdGI7qCDQ=');
+  scriptEl2.setAttribute('crossorigin', 'anonymous');
+  scriptEl2.setAttribute('src', 'https://cdn.jsdelivr.net/npm/markdown-it@12.0.6/dist/markdown-it.js');
+  document.body.appendChild(scriptEl2);
   // <script src="https://cdn.jsdelivr.net/npm/axios@0.21.1/dist/axios.min.js" integrity="sha256-JLmknTdUZeZZ267LP9qB+/DT7tvxOOKctSKeUC2KT6E=" crossorigin="anonymous"></script>
   const scriptEl = document.createElement('script');
   scriptEl.setAttribute('defer', 'defer');
@@ -395,6 +402,24 @@ function removeSubsequentElems(parentSelector, childSelector, subsequentChildSel
     parentNode.removeChild(el);
   });
   return subsequentElems;
+}
+
+function renderSelfServiceSupportOptionsToHtml(options) {
+  const markdownItInstance = window.markdownit();
+  const html = options
+    .map((option) => {
+      const { id, question, answer } = option;
+      const questionHtml = markdownItInstance.render(question);
+      const answerHtml = markdownItInstance.render(answer);
+      return `
+      <div class="question-and-answer">
+        <h3 id="question--${id}" class="question">${questionHtml}</h3>
+        <span class="answer">${answerHtml}</span>
+      </div>
+      `;
+    })
+    .join('\n\n');
+  return html;
 }
 
 // render feature: 2-way peg verifier

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -357,12 +357,12 @@ function renderRskTokenBridgeSupportSetup() {
 }
 
 function renderRskTokenBridgeSupport() {
-  console.log(window.axios);
   const checkButton = document.querySelector('#rsk-token-bridge-support-check-button');
   checkButton.addEventListener('click', onRskTokenBridgeSupportCheckButtonClicked);
 }
 
 function onRskTokenBridgeSupportCheckButtonClicked() {
+  // const selfServiceSupportBaseUrl = 'http://localhost:11375';
   const selfServiceSupportBaseUrl = 'https://self-service-support.vercel.app';
   const txHash = document.querySelector('#rsk-token-bridge-support-txHash').value;
   const fromNetwork = document.querySelector('#rsk-token-bridge-support-fromNetwork').value;
@@ -374,7 +374,7 @@ function onRskTokenBridgeSupportCheckButtonClicked() {
     url,
     method: 'get',
     headers: {
-      'Accept': 'text/html',
+      'Accept': 'application/json',
     },
     timeout: 2000,
     responseType: 'html',
@@ -384,12 +384,22 @@ function onRskTokenBridgeSupportCheckButtonClicked() {
     .then((response) => {
       console.log(response);
       removeSubsequentElems('.main-central-col', '.rsk-token-bridge-support', 'p');
-      const outputHtml = response.data || response;
-      outputArea.innerHTML = `<h2>Result</h2><br>${outputHtml}`;
+      const responseDataOptions = (response && response.data && response.data.options);
+      if (!responseDataOptions) {
+        outputArea.innerText = `Error\n\nUnable to render fetched response\n\n`;
+      } else {
+        const outputHtml = renderSelfServiceSupportOptionsToHtml(responseDataOptions);
+        outputArea.innerHTML = `<h2>Result</h2><br>${outputHtml}`;
+      }
     })
     .catch((error) => {
       console.error(error);
-      outputArea.innerHTML = `<h2>Error</h2><br><pre>${error.toString()}</pre>`;
+      const errorResponseData = (error && error.response && error.response.data);
+      if (errorResponseData) {
+        outputArea.innerText = `Error\n\n${errorResponseData.error}\n\n${errorResponseData.value.join('\n\n')}\n\n`;
+      } else {
+        outputArea.innerText = `Error\n\n${error.message}\n\n`;
+      }
     });
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -78,6 +78,9 @@ $(document).ready(function () {
       case 'next-elem-class':
         renderNextElemClassSetup();
         return;
+      case 'rsk-token-bridge-support':
+        renderRskTokenBridgeSupportSetup();
+        return;
       default:
         console.error('Unsupported render feature:', feature);
     }
@@ -331,6 +334,65 @@ function renderEquation(el) {
   equationEl.setAttribute('title', equation);
   equationEl.classList.add('tex-rendered');
   el.replaceWith(equationEl);
+}
+
+// render feature: Rsk Token Bridge Support
+
+function renderRskTokenBridgeSupportSetup() {
+  // <script defer src="https://unpkg.com/axios/dist/axios.min.js"></script>
+  const scriptEl = document.createElement('script');
+  scriptEl.setAttribute('defer', 'defer');
+  scriptEl.setAttribute('src', 'https://unpkg.com/axios/dist/axios.min.js');
+  scriptEl.setAttribute('onload', 'renderRskTokenBridgeSupport();');
+  document.body.appendChild(scriptEl);
+}
+
+function renderRskTokenBridgeSupport() {
+  console.log(window.axios);
+  const checkButton = document.querySelector('#rsk-token-bridge-support-check-button');
+  checkButton.addEventListener('click', onRskTokenBridgeSupportCheckButtonClicked);
+}
+
+function onRskTokenBridgeSupportCheckButtonClicked() {
+  const selfServiceSupportBaseUrl = 'https://self-service-support.vercel.app';
+  const txHash = document.querySelector('#rsk-token-bridge-support-txHash').value;
+  const fromNetwork = document.querySelector('#rsk-token-bridge-support-fromNetwork').value;
+  const walletName = document.querySelector('#rsk-token-bridge-support-walletName').value;
+  const outputArea = document.querySelector('.rsk-token-bridge-support-output-area');
+  const url =
+    `${selfServiceSupportBaseUrl}/api/v1/rsk-token-bridge/options?fromNetwork=${fromNetwork}&txHash=${txHash}&walletName=${walletName}`;
+  const reqOptions = {
+    url,
+    method: 'get',
+    headers: {
+      'Accept': 'text/html',
+    },
+    timeout: 2000,
+    responseType: 'html',
+  };
+  axios
+    .request(reqOptions)
+    .then((response) => {
+      console.log(response);
+      removeSubsequentElems('.main-central-col', '.rsk-token-bridge-support', 'p');
+      const outputHtml = response.data || response;
+      outputArea.innerHTML = `<h2>Result</h2><br>${outputHtml}`;
+    })
+    .catch((error) => {
+      console.error(error);
+      outputArea.innerHTML = `<h2>Error</h2><br><pre>${error.toString()}</pre>`;
+    });
+}
+
+function removeSubsequentElems(parentSelector, childSelector, subsequentChildSelector) {
+  const parentNode = document.querySelector(parentSelector);
+  const subsequentElems = Array.from(
+    parentNode.querySelectorAll(`${childSelector} ~ ${subsequentChildSelector}`),
+  );
+  subsequentElems.forEach(function(el) {
+    parentNode.removeChild(el);
+  });
+  return subsequentElems;
 }
 
 // render feature: 2-way peg verifier

--- a/kb/tokenbridge-troubleshooting.md
+++ b/kb/tokenbridge-troubleshooting.md
@@ -3,11 +3,47 @@ title: 'RSK Token Bridge Troubleshooting Guide'
 description: 'Having issues crossing your tokens on the token bridge? See the troubleshooting guide for help.'
 tags: knowledge-base, tokenbridge, blockchain, developers, tokens
 layout: 'rsk'
+render_features: 'rsk-token-bridge-support'
 ---
 
 See the [Token Bridge FAQs](https://developers.rsk.co/tools/tokenbridge/faq/)
 
 Visit the [Mainnet Token Bridge](https://tokenbridge.rsk.co/) or the [Testnet Token Bridge](https://testnet.tokenbridge.rsk.co/)
+
+<div class="rsk-token-bridge-support">
+  <div class="rsk-token-bridge-support-input-area">
+    <div>
+      <label>Transaction Hash</label>
+      <br />
+      <input name="txHash" id="rsk-token-bridge-support-txHash" type="text" />
+    </div>
+    <div>
+      <label>Crossing from</label>
+      <br />
+      <select name="fromNetwork" id="rsk-token-bridge-support-fromNetwork">
+        <option value="ethereum-mainnet">Ethereum to RSK</option>
+        <option value="rsk-mainnet">RSK to Etherteum</option>
+      </select>
+    </div>
+    <div>
+      <label>Wallet</label>
+      <br />
+      <select name="walletName" id="rsk-token-bridge-support-walletName">
+        <option value="metamask">MetaMask</option>
+        <option value="nifty">Nifty</option>
+        <option value="liquality">Liquality</option>
+      </select>
+    </div>
+    <div>
+      <button id="rsk-token-bridge-support-check-button">Check &hellip;</button>
+    </div>
+  </div>
+  <div class="rsk-token-bridge-support-output-area">
+  </div>
+</div>
+
+> Note that what follows below are generic troubleshooting queries.
+> To see more specific information, use the form above.
 
 1 - **Transferred tokens from Ethereum, and after 24 hours have not received tokens on RSK**
 
@@ -15,8 +51,7 @@ Visit the [Mainnet Token Bridge](https://tokenbridge.rsk.co/) or the [Testnet To
 
 **When:** Current Block - Transaction Block Number < 5760
 
-**Answer:** 24 hours is an approximation, it is not fixed. Wait until 5760 blocks have past since the transaction block number, plus 5 minutes. 
-
+**Answer:** 24 hours is an approximation, it is not fixed. Wait until 5760 blocks have past since the transaction block number, plus 5 minutes.
 
 2 - **Transferred tokens from Ethereum, and after 24 hours have not received tokens on RSK**
 


### PR DESCRIPTION
## What

- added a self-service support form to the token bridge trouble shooting page
 
## Why

-  user is currently presented with a generic list of all the possible things that could be wrong,
   and left to decipher which ones are applicable
- this form filters the full list of options to a smaller subset that is only applicable to their specific case,
  and for some options augments it with some additional information.

## Refs

- Original implementation: https://github.com/bguiz/self-service-support
