### PR TITLE
Docs: Added tags to all pages missing "tags: " in their front matter

### DIFF
--- a/_includes/rif-id/rlogin-libraries.md
+++ b/_includes/rif-id/rlogin-libraries.md
@@ -1,3 +1,10 @@
+---
+layout: rsk
+title: rLogin Libraries
+description: 'multiple libraries that enable seamless integration to rLogin protocols'
+tags: rlogin, libraries, architecture, rif, identity, vault, marketplace, auth, rif-data-vault, rns, ui
+---
+
 The implementation of the architecture defined above consists of multiple libraries that enable seamless integration to rLogin protocols:
 - The [RIF Data Vault](/rif/identity/data-vault) - a user-centric cloud storage service
 - [Verifiable Credential JSON Schemas](/rif/identity/rlogin/libraries/vc-json-schemas) and [parser](/rif/identity/rlogin/libraries/vc-json-schemas-parser) - proposes unique standard interface for Verifiable Credentials

--- a/_rsk/node/install/aws.md
+++ b/_rsk/node/install/aws.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Setup node on AWS
+tags: aws, console, VVM, marketplace, launch, desktop, install, rsk, rskj, node, how-to, network, requirements, mainnet
 collection_order: 2332
 ---
 

--- a/_rsk/node/install/azure.md
+++ b/_rsk/node/install/azure.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Setup node on Azure
+tags: azure, desktop, rpc, install, rsk, rskj, node, how-to, network, requirements, mainnet
 collection_order: 2331
 ---
 

--- a/_rsk/node/install/centos.md
+++ b/_rsk/node/install/centos.md
@@ -2,6 +2,7 @@
 layout: rsk
 title: Setup node on CentOS
 description: "How to install and run an RSK node on CentOS"
+tags: rsk, node, centos, install, rskj,  requirements, how-to, network, configurations, mainnet
 collection_order: 2323
 ---
 

--- a/_rsk/node/install/docker.md
+++ b/_rsk/node/install/docker.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Setup node on Docker
+tags: docker, desktop, macOS, rskj, windows, install, rsk, node, how-to, network, requirements, mainnet
 collection_order: 2321
 ---
 

--- a/_rsk/node/install/java.md
+++ b/_rsk/node/install/java.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Setup node on Java
+tags: java, install, rsk, rskj, node, how-to, network, requirements, mainnet, jar
 collection_order: 2324
 render_features: 'custom-terminals'
 ---

--- a/_rsk/node/install/ubuntu.md
+++ b/_rsk/node/install/ubuntu.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Setup node on Ubuntu
+tags: ubuntu, install, rsk, rskj, node, how-to, network, requirements, mainnet
 collection_order: 2322
 ---
 

--- a/_rsk/rbtc/gas.md
+++ b/_rsk/rbtc/gas.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Gas
+tags: gas, transactions, rbtc, mainnet, smart-contracts, rsk, conversion, bitcoin, price, gas-price, cost
 collection_order: 3200
 ---
 

--- a/_rsk/rbtc/index.md
+++ b/_rsk/rbtc/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RBTC Token
+tags: mainnet, token, transactions, rbtc, gas, smart-contracts, rsk, conversion, price, gas-price, gas-cost, smart bitcoin, bitcoin
 collection_order: 3000
 permalink: /rsk/rbtc/
 ---

--- a/develop/apps/integrate.md
+++ b/develop/apps/integrate.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: How to Integrate
+tags: apps, integrate, node, linux, windows, mac, rbtc, defi, decentralized, quick-start, guides, tutorial, testnet, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets
 ---
 
 ## Step 1: Install a node

--- a/develop/apps/tools/gas-station.md
+++ b/develop/apps/tools/gas-station.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Gas Station
+tags: gas, gas-station, rbtc, defi, decentralized, quick-start, guides, tutorial, testnet, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets
 ---
 
 ## Gas Station

--- a/develop/json-rpc-api.md
+++ b/develop/json-rpc-api.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: JSON-RPC API
+tags: API, json, rpc, json-rpc, transactions, quick-start, guides, tutorial, testnet, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, sidechain, contracts, mining
 ---
 
 These methods are meant to be used for mining. Mining pools should interact with this API in order to do merged mining.

--- a/ethereum-dapp-to-rsk/index.md
+++ b/ethereum-dapp-to-rsk/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Bring your Ethereum token to RSK
+tags: token, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Our goal is to join forces and give options to people who believe in the power of smart contracts, and also believe in the security of Bitcoin, through RSK. Bring your Ethereum token to RSK!

--- a/libraries/index.md
+++ b/libraries/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Libs
+tags: libraries, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RSK Libraries

--- a/libraries/web3/personal.md
+++ b/libraries/web3/personal.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: web3.personal
+tags: web3, libraries, console, rpc, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, crypto
 ---
 
 For this , it is supposed that you have an RSK node running. Be sure your node has enabled personal module in the config file. Method personal.newAccount will be used.
@@ -10,6 +11,7 @@ For this , it is supposed that you have an RSK node running. Be sure your node h
 There are two simple ways to call RPC methods:
 
 ## Using RSK console
+
 There's a interactive console that allows you to send commands to an RSK node, it's just a node.js application that can be downloaded from <a href="https://github.com/rsksmart/utilities/tree/master/console" target="_blank">here</a>.
 
 From the command line, execute node console.js -server HOST:PORT. If everything worked as expected, you should see the RSK command prompt displayed. Run this command with a passphrase that you choose as parameter:

--- a/newsletter/index.md
+++ b/newsletter/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Newsletter
+tags: newsletter, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 

--- a/rif/communication/architecture.md
+++ b/rif/communication/architecture.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Architecture
+tags: rif, rif-communication, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 RIF Communication consist of 3 distinct layers (from the top to the bottom as shown in the figure below):

--- a/rif/communication/index.md
+++ b/rif/communication/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: About RIF Communication
+tags: rif, rif-storage, communication, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 RIF Communications is an infrastructure protocol built on top of libp2p, which allows parties in a peer-to-peer network to discover each other and establish secure communication channels, with assured anonymity, confidentiality, integrity, and authenticity.

--- a/rif/identity/about.md
+++ b/rif/identity/about.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: About
+tags: rlogin, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - IOV Labs site: [iovlabs.org](https://iovlabs.org/)

--- a/rif/identity/contribute.md
+++ b/rif/identity/contribute.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, beta, build, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, develop, git, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # RIF Identity Git approach

--- a/rif/identity/data-vault/architecture/client.md
+++ b/rif/identity/data-vault/architecture/client.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, architecture, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data vault - Centralized pinner client

--- a/rif/identity/data-vault/architecture/index.md
+++ b/rif/identity/data-vault/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, architecture, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data vault - Architecture

--- a/rif/identity/data-vault/architecture/provider.md
+++ b/rif/identity/data-vault/architecture/provider.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, architecture, provider, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data vault - Centralized pinner provider

--- a/rif/identity/data-vault/architecture/service.md
+++ b/rif/identity/data-vault/architecture/service.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, architecture, service, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data vault - Centralized IPFS pinner service

--- a/rif/identity/data-vault/develop.md
+++ b/rif/identity/data-vault/develop.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data Vault - Develop

--- a/rif/identity/data-vault/index.md
+++ b/rif/identity/data-vault/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data vault

--- a/rif/identity/data-vault/use.md
+++ b/rif/identity/data-vault/use.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, data-vault, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Data Vault - Use

--- a/rif/identity/definitions.md
+++ b/rif/identity/definitions.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, seed, mnemonics, key, persona, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Definitions

--- a/rif/identity/faq.md
+++ b/rif/identity/faq.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## FAQ

--- a/rif/identity/index.md
+++ b/rif/identity/index.md
@@ -1,8 +1,6 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # RIF Identity

--- a/rif/identity/libraries/core.md
+++ b/rif/identity/libraries/core.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, core, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Identity Core

--- a/rif/identity/libraries/daf.md
+++ b/rif/identity/libraries/daf.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, uport, daf-bindings, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## uPort DAF bindings

--- a/rif/identity/libraries/ethr-did-utils.md
+++ b/rif/identity/libraries/ethr-did-utils.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, utils, ethr-did-utils, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Ethr DID Utils

--- a/rif/identity/libraries/ethr-did.md
+++ b/rif/identity/libraries/ethr-did.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, ethr-did, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Ethr DID

--- a/rif/identity/libraries/index.md
+++ b/rif/identity/libraries/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Libraries

--- a/rif/identity/libraries/mnemonics.md
+++ b/rif/identity/libraries/mnemonics.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, node, mnemonics, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Mnemonic module

--- a/rif/identity/libraries/node-utils.md
+++ b/rif/identity/libraries/node-utils.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, utils, node, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Node Utils

--- a/rif/identity/libraries/rsk-ethr-did.md
+++ b/rif/identity/libraries/rsk-ethr-did.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Seamless RSK DIDs on RSK

--- a/rif/identity/manager/architecture.md
+++ b/rif/identity/manager/architecture.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, rif-identity-manager, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Identity Manager - design & architecture

--- a/rif/identity/manager/develop.md
+++ b/rif/identity/manager/develop.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, manager, libraries, develop, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Identity Manager - develop

--- a/rif/identity/manager/index.md
+++ b/rif/identity/manager/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, manager, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Identity Manager

--- a/rif/identity/manager/user-guide/index.md
+++ b/rif/identity/manager/user-guide/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, manager, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Identity Manager - User Guide

--- a/rif/identity/mvp/acknowledgements.md
+++ b/rif/identity/mvp/acknowledgements.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## The MVP - Acknowledgements

--- a/rif/identity/mvp/applications/holder-app.md
+++ b/rif/identity/mvp/applications/holder-app.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Citizens App - wallet-like mobile application (Android)

--- a/rif/identity/mvp/applications/index.md
+++ b/rif/identity/mvp/applications/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## The MVP - Applications

--- a/rif/identity/mvp/applications/issuer-app.md
+++ b/rif/identity/mvp/applications/issuer-app.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Government app - web application listing credential requests

--- a/rif/identity/mvp/applications/verifier-app.md
+++ b/rif/identity/mvp/applications/verifier-app.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Police officers app - QR-scanner-like mobile application (Android)

--- a/rif/identity/mvp/architecture.md
+++ b/rif/identity/mvp/architecture.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## The MVP - Design & Architecture

--- a/rif/identity/mvp/index.md
+++ b/rif/identity/mvp/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## The MVP

--- a/rif/identity/mvp/learnings.md
+++ b/rif/identity/mvp/learnings.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## The MVP - Learnings

--- a/rif/identity/mvp/run.md
+++ b/rif/identity/mvp/run.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## The MVP - Run Locally

--- a/rif/identity/mvp/services/convey-service.md
+++ b/rif/identity/mvp/services/convey-service.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, service, jwt, ipfs, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Convey service - Public transport layer for JWTs using IPFS

--- a/rif/identity/mvp/services/data-vault.md
+++ b/rif/identity/mvp/services/data-vault.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, service, data-vault, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 <div class="alert alert-danger">

--- a/rif/identity/mvp/services/index.md
+++ b/rif/identity/mvp/services/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, service, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Services

--- a/rif/identity/mvp/services/issuer-service.md
+++ b/rif/identity/mvp/services/issuer-service.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, service, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Issuer service

--- a/rif/identity/references.md
+++ b/rif/identity/references.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, reference, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # References

--- a/rif/identity/rlogin/architecture.md
+++ b/rif/identity/rlogin/architecture.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin - Design & Architecture

--- a/rif/identity/rlogin/develop.md
+++ b/rif/identity/rlogin/develop.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, integrate, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin - Develop

--- a/rif/identity/rlogin/integrate/index.md
+++ b/rif/identity/rlogin/integrate/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, integrate, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin - Integrate

--- a/rif/identity/rlogin/integrations.md
+++ b/rif/identity/rlogin/integrations.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, integrate, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin - Integrations

--- a/rif/identity/rlogin/libraries/express-did-auth.md
+++ b/rif/identity/rlogin/libraries/express-did-auth.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, express-did-auth, auth, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Express DID Auth - a challenge-response authentication model based in DIDs

--- a/rif/identity/rlogin/libraries/modal.md
+++ b/rif/identity/rlogin/libraries/modal.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, modal, rif, rif-identity, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin - modal

--- a/rif/identity/rlogin/libraries/vc-json-schemas-parser.md
+++ b/rif/identity/rlogin/libraries/vc-json-schemas-parser.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin - Verifiable Credentials JSON Schemas parser

--- a/rif/identity/rlogin/samples.md
+++ b/rif/identity/rlogin/samples.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rlogin, rif, rif-identity, samples, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## rLogin samples

--- a/rif/identity/specs/convey-service.md
+++ b/rif/identity/specs/convey-service.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Convey service

--- a/rif/identity/specs/credential-requests.md
+++ b/rif/identity/specs/credential-requests.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, credential, request, self-sovereign, DID, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Verifiable credential requests protocol

--- a/rif/identity/specs/did-auth.md
+++ b/rif/identity/specs/did-auth.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, spcs, specification, auth, DID, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # DID authentication
@@ -11,6 +12,7 @@ A challenge–response authentication is a family of protocols in which one part
 DID Auth is a protocol that allows asking the controller of an account to sign a random message, thus demonstrating control of the account at the time of the question. This protocol used as a login method checks that the user controls the account at the time of access to the application.
 
 Additionally, it allows the application to request specific data at the time of registration, for example the user's email or phone number. These requested data follow a specific standard, which allows the client to provide it in a unified way and even cryptographically signed by a third party. This means that the application can ask the user for verifiable credentials, identifying them by their type in a unique way.
+
 ### Table of contents
 
 - [State of the art](#state-of-the-art)

--- a/rif/identity/specs/encryption-layout.md
+++ b/rif/identity/specs/encryption-layout.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, encryption, infrastructure, DID, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Encryption layout

--- a/rif/identity/specs/identity-layout.md
+++ b/rif/identity/specs/identity-layout.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, libraries, infrastructure, mobile, DID, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Identity layout

--- a/rif/identity/specs/index.md
+++ b/rif/identity/specs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, specs, DID, encrytpion, layout, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Specs

--- a/rif/identity/specs/presentation-timestamps.md
+++ b/rif/identity/specs/presentation-timestamps.md
@@ -1,5 +1,6 @@
 ---
 layout: rsk
+tags: rif, rif-identity, timestamps, credentials, DID, libraries, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # Presentations timestamps

--- a/rif/index.md
+++ b/rif/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RSK Infrastructure Framework
+tags: rif, rif-storage, rif-lumino, rns, rif-identity, DID, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Services

--- a/rif/lumino/explorer/index.md
+++ b/rif/lumino/explorer/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Lumino Explorer - How To Use
+tags: rif, rif-lumino, payments, node, lumino, explorer, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - [Repository](https://github.com/rsksmart/lumino-explorer)

--- a/rif/lumino/explorer/own/api.md
+++ b/rif/lumino/explorer/own/api.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Lumino Explorer API
+tags: rif, rif-lumino, payments, node, lumino, explorer, api sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Pre requisites

--- a/rif/lumino/explorer/own/index.md
+++ b/rif/lumino/explorer/own/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Run your own explorer
+tags: rif, rif-lumino, payments, node, lumino, explorer, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 If you want to run your own explorer, you have to setup the API and the web components.

--- a/rif/lumino/explorer/own/web.md
+++ b/rif/lumino/explorer/own/web.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Lumino Explorer WEB
+tags: rif, rif-lumino, payments, node, lumino, explorer, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Pre requisites

--- a/rif/lumino/index.md
+++ b/rif/lumino/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Lumino Network
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The RIF Lumino Network is the first off-chain state channel network launched on RSK. It is also a cornerstone of a broader vision called RIF Payments which will allow users to seamlessly interact with multiple cross-blockchain off-chain networks such as Lumino, Lightning and Raiden.

--- a/rif/lumino/libraries/index.md
+++ b/rif/lumino/libraries/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Libraries
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The developer community is working to help other developers build libraries and SDKs.

--- a/rif/lumino/libraries/lumino-js.md
+++ b/rif/lumino/libraries/lumino-js.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Lumino JS SDK
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 

--- a/rif/lumino/node/architecture.md
+++ b/rif/lumino/node/architecture.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Architecture
+tags: rif, rif-lumino, payments, node, lumino, sdk, architecture, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # TODO: missing doc

--- a/rif/lumino/node/contribute.md
+++ b/rif/lumino/node/contribute.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Creating an Issue
+tags: rif, rif-lumino, contribute, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 If you find an issue in Lumino and want to report it, or if you want to request a feature, you can make an issue in the [GitHub repo](https://github.com/rsksmart/lumino). 

--- a/rif/lumino/node/index.md
+++ b/rif/lumino/node/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Lumino Node
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Here you'll find more information about the Lumino Node:

--- a/rif/lumino/node/install/index.md
+++ b/rif/lumino/node/install/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Get your own RIF Lumino node up and running 
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 To know more on how to install a Lumino node, please refer to the Github documentation:

--- a/rif/lumino/node/protocol.md
+++ b/rif/lumino/node/protocol.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Protocol
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # TODO: missing doc

--- a/rif/lumino/node/use.md
+++ b/rif/lumino/node/use.md
@@ -2,6 +2,7 @@
 layout: rsk
 title: How To Use
 description: "How to build and run a Lumino node. How to use its user interface to view the dashboard, quick payments, token view, send tokens, pay, deposit, open and close channels, and view payments"
+tags: rif, rif-lumino, payments, node, lumino, sdk, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Build your Lumino Node

--- a/rif/lumino/public-repos.md
+++ b/rif/lumino/public-repos.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Public repositories
+tags: rif, rif-lumino, payments, node, lumino, light-client, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Check out our public repositories:

--- a/rif/rns/architecture/Deed.md
+++ b/rif/rns/architecture/Deed.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Deed
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 <div class="alert alert-danger">

--- a/rif/rns/architecture/MultiCryptoResolver.md
+++ b/rif/rns/architecture/MultiCryptoResolver.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Multi-Crypto Resolver
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Multi-Crypto Resolver

--- a/rif/rns/architecture/NameResolver.md
+++ b/rif/rns/architecture/NameResolver.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Name Resolver
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Return a valid RNS name for the requested node, or the empty string if no name is defined for the requested node.

--- a/rif/rns/architecture/Registrar.md
+++ b/rif/rns/architecture/Registrar.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Registrar
+tags: rif, rns, rif-name-service, registrar, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 <div class="alert alert-danger">

--- a/rif/rns/architecture/Resolver.md
+++ b/rif/rns/architecture/Resolver.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Resolver
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The Resolver contract handles the resolution between the name domain and the resource. Each Registry entry references a Resolver. Use one of our resolvers, the [Multi-Crypto Resolver](/rif/rns/architecture/MultiCryptoResolver), or the [RSK Resolver](/rif/rns/architecture/RSKResolver).

--- a/rif/rns/architecture/ReverseRegistrar.md
+++ b/rif/rns/architecture/ReverseRegistrar.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Reverse Registrar
+tags: rif, rns, rif-name-service, reverse-registrar, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The owner of the `addr.reverse` domain is a registrar that permits the caller to take ownership of the reverse record for their own address.

--- a/rif/rns/architecture/definitive-resolver.md
+++ b/rif/rns/architecture/definitive-resolver.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Resolver
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - RSK Mainnet: [`0xD87f8121D44F3717d4bAdC50b24E50044f86D64B`](https://explorer.rsk.co/address/0xd87f8121d44f3717d4badc50b24e50044f86d64b)

--- a/rif/rns/architecture/index.md
+++ b/rif/rns/architecture/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Architecture
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The RIF Name Service architecture is based on 3 main components:

--- a/rif/rns/architecture/registry.md
+++ b/rif/rns/architecture/registry.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Registry
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The RNS Registry is the contract that stores the ownership of the nodes.

--- a/rif/rns/architecture/rsk-registrar/index.md
+++ b/rif/rns/architecture/rsk-registrar/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: .rsk Registrar
+tags: rif, rns, rif-name-service, registrar, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The registrar is separated into several components for simplicity, modularity, and privilege minimization. [RSK Owner](rskowner) is the owner of rsk top level domain, so it is the only contract that can invoke `setSubdomainOwner` in [RNS Registry](../registry#setsubnodeowner). It grants access to other contracts for registering new domains and/or renewing domain's expiration time. Currently we've enabled a [first-in first-served registrar](registrars/fifs) contract and a [simple renewer](renewers/renewer) contract that enable minimal actions to provide basic functionality for domain creation and administration.

--- a/rif/rns/architecture/rsk-registrar/other/nameprice.md
+++ b/rif/rns/architecture/rsk-registrar/other/nameprice.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Name Price
+tags: rif, rns, rif-name-service, name price, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - MainNet: [0xd09adf13e482928e47e96dd6f02aad1daf7a5a47](https://explorer.rsk.co/address/0xd09adf13e482928e47e96dd6f02aad1daf7a5a47)

--- a/rif/rns/architecture/rsk-registrar/registrars/fifs.md
+++ b/rif/rns/architecture/rsk-registrar/registrars/fifs.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: First-in first-served .rsk registrar
-tags: rns, fifs, registrar
+tags: rif, rns, fifs, registrar, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 description: "Register an RNS address using the FIFS registrar, without address resolution"
 ---
 

--- a/rif/rns/architecture/rsk-registrar/registrars/fifsaddr.md
+++ b/rif/rns/architecture/rsk-registrar/registrars/fifsaddr.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: First-in first-served + address setup .rsk registrar
-tags: rns, fifs, registrar
+tags: rif, rns, fifs, registrar, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 description: "Register an RNS address using the FIFS registrar, with address resolution"
 ---
 

--- a/rif/rns/architecture/rsk-registrar/registrars/index.md
+++ b/rif/rns/architecture/rsk-registrar/registrars/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RSK Registrars
-tags: rns, registrar
+tags: rif, rns, rif-name-service, javascript, registrar,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 description: "RNS registrars"
 ---
 

--- a/rif/rns/architecture/rsk-registrar/renewers/index.md
+++ b/rif/rns/architecture/rsk-registrar/renewers/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RSK Renewers
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - [Simple renewer](renewer)

--- a/rif/rns/architecture/rsk-registrar/renewers/renewer.md
+++ b/rif/rns/architecture/rsk-registrar/renewers/renewer.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Renewer
+tags: rif, renewer, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - RSK MainNet: [0x7a9872a7615c475b62a62b8f6e491077fb05f663](https://explorer.rsk.co/address/0x7a9872a7615c475b62a62b8f6e491077fb05f663)

--- a/rif/rns/architecture/rsk-registrar/rskowner.md
+++ b/rif/rns/architecture/rsk-registrar/rskowner.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RSK Owner
+tags: rif, rns, rif-name-service, registrar, rsk-owner, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - RSK MainNet: [0x45d3e4fb311982a06ba52359d44cb4f5980e0ef1](https://explorer.rsk.co/address/0x45d3e4fb311982a06ba52359d44cb4f5980e0ef1)

--- a/rif/rns/index.md
+++ b/rif/rns/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Name Service
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 RNS provides an architecture which enables the identification of blockchain addresses by human-readable names.

--- a/rif/rns/integrate/domain-keys-management.md
+++ b/rif/rns/integrate/domain-keys-management.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Domain keys management guidelines
+tags: rif, rns, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Work in progress :hammer:

--- a/rif/rns/integrate/domain-registration.md
+++ b/rif/rns/integrate/domain-registration.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Domain keys management guidelines
+tags: rif, rns, rif-name-service, resolver, domain, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Work in progress :hammer:

--- a/rif/rns/integrate/index.md
+++ b/rif/rns/integrate/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS Integration guidelines
-tags: rif rns integrate
+tags: rif, rns, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 description: Learn how to integrate RNS with your wallet or dApp.
 tags: rns, javascript, dapp, wallet, integrate
 ---

--- a/rif/rns/integrate/integrate-addr-resolution.md
+++ b/rif/rns/integrate/integrate-addr-resolution.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Use domains instead of long hexa addresses
+tags: rif, rns, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This is a demonstration of how to get the address of a domain. We are going to do it in a React app.

--- a/rif/rns/integrate/integrate-dapp.md
+++ b/rif/rns/integrate/integrate-dapp.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: Integrate your dApp with RNS
-tags: rif rns integrate
+tags: rif, rns, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 description: Learn how to integrate RNS with your dApp.
 tags: rns, javascript, dapp, integrate
 ---

--- a/rif/rns/integrate/integrate-wallet.md
+++ b/rif/rns/integrate/integrate-wallet.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: Integrate your wallet with RNS
-tags: rns, wallet, javascript, integrate
+tags: rif, rns, javascript, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The first thing you need to do is to register the name of your wallet now! Search for it here:

--- a/rif/rns/integrate/multichain-address-resolution.md
+++ b/rif/rns/integrate/multichain-address-resolution.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Multi-chain address resolution guidelines
+tags: rif, rns, multi-chain, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Resolving a chain address (for example, a Bitcoin address) associated to a domain consist of 4 steps:

--- a/rif/rns/integrate/reverse-resolution.md
+++ b/rif/rns/integrate/reverse-resolution.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Reverse address resolution
+tags: rif, rns, rif-name-service, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Finding the domain associated with an address consists of X steps:

--- a/rif/rns/libs/Android.md
+++ b/rif/rns/libs/Android.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Android Library
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, android, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Android Library to resolve your RIF Name Service address on your app.

--- a/rif/rns/libs/Python.md
+++ b/rif/rns/libs/Python.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Python Library
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, python, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 [Python Library](https://github.com/rnsdomains/rns-python-lib) to resolve your RIF Name Service address on your app.

--- a/rif/rns/libs/iOS.md
+++ b/rif/rns/libs/iOS.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: iOS Library
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, ios, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Implementation for resolvers for the RIF Name Service, available for iOS.

--- a/rif/rns/libs/index.md
+++ b/rif/rns/libs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS Libraries
-tags: rns, libs
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 RIF Name Service is part of the RIF Open Platform ecosystem.

--- a/rif/rns/libs/javascript/Advanced-usage.md
+++ b/rif/rns/libs/javascript/Advanced-usage.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Advanced Usage
-tags: rns, javascript
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Instantiate the lib with your local blockchain

--- a/rif/rns/libs/javascript/Contribute.md
+++ b/rif/rns/libs/javascript/Contribute.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Contribute
-tags: rns, javascript
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Run for development

--- a/rif/rns/libs/javascript/Errors.md
+++ b/rif/rns/libs/javascript/Errors.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Error knowledge base
-tags: rns, javascript, error
+tags: rif, rns, error, knowledge-base, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Handle errors with RNS library

--- a/rif/rns/libs/javascript/Getting-started.md
+++ b/rif/rns/libs/javascript/Getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Getting Started
-tags: rns, javascript
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Installation

--- a/rif/rns/libs/javascript/Operations.md
+++ b/rif/rns/libs/javascript/Operations.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Operations
-tags: rns, javascript
+tags: rif, rns, rif-name-service, operations, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Available operations

--- a/rif/rns/libs/javascript/RNS-instance.md
+++ b/rif/rns/libs/javascript/RNS-instance.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Instance
-tags: rns, javascript
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Installation

--- a/rif/rns/libs/javascript/Utils.md
+++ b/rif/rns/libs/javascript/Utils.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library - Utils
-tags: rns, javascript
+tags: rif, rns, rif-name-service, utils, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Available methods

--- a/rif/rns/libs/javascript/index.md
+++ b/rif/rns/libs/javascript/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS JS Library
-tags: rns, javascript
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 description: Learn more about RNS JS Library.
 ---
 

--- a/rif/rns/libs/rns-artifacts/resolver/index.md
+++ b/rif/rns/libs/rns-artifacts/resolver/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS Solidity artifacts - resolvers
-tags: rns, artifacts, resolvers
+tags: rif, rns, artifacts, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The Resolver contract handles the resolution between the name domain and the resource. Each Registry entry references a Resolver.

--- a/rif/rns/libs/rns-artifacts/resolver/string-resolver.md
+++ b/rif/rns/libs/rns-artifacts/resolver/string-resolver.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
 title: RNS Solidity artifacts - String Resolver
-tags: rns, artifacts, resolvers, string resolver
+tags: rif, rns, rif-name-service, artifacts, javascript,  domains, address, integrate, resolver, string-resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 String Resolver provides an RNS domain of a string resolution.

--- a/rif/rns/libs/smart-contracts.md
+++ b/rif/rns/libs/smart-contracts.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Full smart contracts suite
+tags: rif, rns, rif-name-service, javascript,  domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Import contracts using [npm](https://www.npmjs.com/).

--- a/rif/rns/mainnet.md
+++ b/rif/rns/mainnet.md
@@ -2,6 +2,7 @@
 layout: rsk
 title: RNS Mainnet
 tags: [rif, rns, mainnet]
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ### RNS

--- a/rif/rns/operations/get-reverse.md
+++ b/rif/rns/operations/get-reverse.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Find the name of an address
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This process describes how to find a name for a given address. This depends on the owner of the account having set its reverse resolution.

--- a/rif/rns/operations/index.md
+++ b/rif/rns/operations/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Operations
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Registration:

--- a/rif/rns/operations/migrate-from-auction.md
+++ b/rif/rns/operations/migrate-from-auction.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Migrate from auction model
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Any name that has been registered using the [Auction Model](/rif/rns/operations/register-auction-deprecated) contract should be migrated to the new [registration model](/rif/rns/operations/register).

--- a/rif/rns/operations/register-auction-deprecated.md
+++ b/rif/rns/operations/register-auction-deprecated.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Register a domain - Deprecated
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 <div class="alert alert-danger">

--- a/rif/rns/operations/register-subdomain.md
+++ b/rif/rns/operations/register-subdomain.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Set subdomain owner
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This operation can be performed for either register a new subdomain or change an existing subdomain's owner.

--- a/rif/rns/operations/register.md
+++ b/rif/rns/operations/register.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Register a domain
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The process consists of three main steps:

--- a/rif/rns/operations/renew.md
+++ b/rif/rns/operations/renew.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Renew a domain
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Don't forget to [migrate](/rif/rns/operations/Migrate-a-name) your name before renewing it!

--- a/rif/rns/operations/resolve.md
+++ b/rif/rns/operations/resolve.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Resolve a domain address
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The Resolver contract handles the resolution between the name domain and the resource. Each Registry entry references a Resolver.

--- a/rif/rns/operations/set-addr.md
+++ b/rif/rns/operations/set-addr.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Set address resolution
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This operation is used to set the address resolution of a domain. If you are using your domain to receive assets, you may use this guide to change the wallet address where you receive payments.

--- a/rif/rns/operations/set-btc-address.md
+++ b/rif/rns/operations/set-btc-address.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Set chain address resolution
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This operation is used to set a chain address resolution of a domain. If you are using your domain to receive assets, you may use this guide to change the wallet address where you receive payments.

--- a/rif/rns/operations/set-resolver.md
+++ b/rif/rns/operations/set-resolver.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Set resolver
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This operation is used to change the resource record types for a domain. Use this guide to set multi-chain resolver for your domain.

--- a/rif/rns/operations/set-reverse.md
+++ b/rif/rns/operations/set-reverse.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Find the name of an address
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This process describes how to expose a name for an owned address. This requires you have the keys to unlock the account.

--- a/rif/rns/operations/transfer.md
+++ b/rif/rns/operations/transfer.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Renew a domain
+tags: rif, rns, rif-name-service, domains, address, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Under development.

--- a/rif/rns/run-locally.md
+++ b/rif/rns/run-locally.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Run RNS locally
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 More information coming soon!

--- a/rif/rns/specs/index.md
+++ b/rif/rns/specs/index.md
@@ -2,7 +2,7 @@
 layout: rsk
 title: RNS Specs
 description: "RNS specifications, and name mapping convention"
-tags: rns
+tags: rif, rns, rif-name-service, integrate, resolver, node, specs, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The domain name space is a tree structure. Each node and leaf on the tree corresponds to a resource set (which may be empty). The domain system makes no distinctions between the uses of the interior nodes and leaves, and this memo uses the term "node" to refer to both.

--- a/rif/rns/specs/registry.md
+++ b/rif/rns/specs/registry.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RNS Specs - Registry
+tags: rif, rns, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The registry contract provides a simple mapping between a domain and its resolver. Everything related to domain ownership is managed in this contract, including ownership transfer and sub-domain creation. Each registry entry refers to a resolver which handles the [resolution](/rif/rns/specs/resolvers) between the name domain and the desired resource.

--- a/rif/rns/specs/resolvers.md
+++ b/rif/rns/specs/resolvers.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RNS Specs - Resolvers
+tags: rif, rns, rif-name-service, integrate, resolver, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Resolvers may implement any subset of the record types specified here. Where a record types specification requires a resolver to provide multiple functions, the resolver MUST implement either all or none of them.

--- a/rif/rns/testnet.md
+++ b/rif/rns/testnet.md
@@ -2,6 +2,7 @@
 layout: rsk
 title: RNS Testnet
 tags: [rif, rns, testnet]
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 You can access the Marketplace on the RSK Tesnet: [marketplace.testnet.rifos.org](https://marketplace.testnet.rifos.org/)

--- a/rif/rns/tools/MyCrypto.md
+++ b/rif/rns/tools/MyCrypto.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: MyCrypto
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 MyCrypto is an open-source, client-side tool for generating ether wallets, handling ERC-20 tokens, and interacting with the blockchain more easily.

--- a/rif/rns/tools/RNS-Manager.md
+++ b/rif/rns/tools/RNS-Manager.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RNS Manager
+tags: rif, rns, rif-name-service, manager, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The [RNS Manager](https://manager.rns.rifos.org) is a simple tool that interacts with RNS Smart Contracts via Metamask. It has the following methods:

--- a/rif/rns/tools/Subdomain-tool.md
+++ b/rif/rns/tools/Subdomain-tool.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RNS Manager
+tags: rif, rns, rif-name-service, sub-domain, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 It's a sample DApp that could be seen as a component to facilitate the adoption of RNS.

--- a/rif/rns/tools/Web3.md
+++ b/rif/rns/tools/Web3.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Web3
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 To use web3 and interact with the contracts, we must instance `web3` with a provider. To do so we can use [RSK public nodes](https://nodes.rsk.co):

--- a/rif/rns/tools/index.md
+++ b/rif/rns/tools/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Tools
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 - [Web3](Web3)

--- a/rif/rns/try-rns.md
+++ b/rif/rns/try-rns.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Try RNS
+tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Welcome to RNS! You can use RSK testnet to try the service for free.

--- a/rif/scheduler/contracts.md
+++ b/rif/scheduler/contracts.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Scheduler - Contracts
+tags: rif, rif-scheduler, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Repo: [`rsksmart/rif-scheduler-contracts`](https://github.com/rsksmart/rif-scheduler-contracts)

--- a/rif/scheduler/index.md
+++ b/rif/scheduler/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Scheduler - A service for scheduling transactions
+tags: rif, rif-scheduler, sdk, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The main motivation of this project is to build a reliable service

--- a/rif/scheduler/run.md
+++ b/rif/scheduler/run.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Scheduler - Run your own scheduler
+tags: rif, rif-scheduler, sdk, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 By running your own scheduler you can provide the transaction execution service.

--- a/rif/scheduler/sdk.md
+++ b/rif/scheduler/sdk.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Scheduler - SDK
+tags: rif, rif-scheduler, sdk, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Repo: [`rsksmart/rif-scheduler-sdk`](https://github.com/rsksmart/rif-scheduler-sdk)

--- a/rif/scheduler/services.md
+++ b/rif/scheduler/services.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Scheduler - Services
+tags: rif, rif-scheduler, sdk, libraries, DID, infrastructure, mobile, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Repo: [`rsksmart/rif-scheduler-services`](https://github.com/rsksmart/rif-scheduler-services)

--- a/rif/storage/architecture.md
+++ b/rif/storage/architecture.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: storage/architecture
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 RIF Storage consist of 3 distinct layers (from the top to the bottom as shown in the figure below):

--- a/rif/storage/index.md
+++ b/rif/storage/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: About RIF Storage
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 RIF Storage is an open, censorship resistant, permissionless and decentralized storage protocol. It provides a unified interface to 3rd party decentralized storage providers like [IPFS](/rif/storage/providers/ipfs) or [Swarm](/rif/storage/providers/swarm). We are adding incentives to these systems to ensure resistance to trivial attacks, availability and to allow participants to be rewarded for their participation in the network.

--- a/rif/storage/libraries/javascript.md
+++ b/rif/storage/libraries/javascript.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Storage JS
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Install

--- a/rif/storage/pinning/index.md
+++ b/rif/storage/pinning/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Storage Pinning service
+tags: rif, rif-storage, rif-pinning, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Storage Pinning service

--- a/rif/storage/pinning/local_cli.md
+++ b/rif/storage/pinning/local_cli.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RIF Storage Pinning service - Local setup with storage dev CLI
+tags: rif, rif-storage, ipfs, rif-pinning, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This guide is quite advanced and assumes a greater knowledge of how to setup local blockchain environment, IFPS, etc. 

--- a/rif/storage/providers/index.md
+++ b/rif/storage/providers/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: storage/providers/index
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 WIP

--- a/rif/storage/providers/ipfs/index.md
+++ b/rif/storage/providers/ipfs/index.md
@@ -1,6 +1,9 @@
 ---
 layout: rsk
 title: IPFS
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
-IPFS stands for Interplanetary File System. At its core it is a versioned file system which can store files and track versions over time, very much like Git. It also defines how files move across a network, making it a distributed file system, much like BitTorrent. In combining these two properties, IPFS enables a new permanent web and augments the way we use existing internet protocols like HTTP.
+IPFS stands for Interplanetary File System. 
+
+At its core it is a versioned file system which can store files and track versions over time, very much like Git. It also defines how files move across a network, making it a distributed file system, much like BitTorrent. In combining these two properties, IPFS enables a new permanent web and augments the way we use existing internet protocols like HTTP.

--- a/rif/storage/providers/swarm/configure.md
+++ b/rif/storage/providers/swarm/configure.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Running Configurations for Swarm
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Use the following cheatsheet to run Swarm with the desired capabilities.

--- a/rif/storage/providers/swarm/guides/debugging.md
+++ b/rif/storage/providers/swarm/guides/debugging.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Debugging Swarm
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## 1. Open the `swarm` project

--- a/rif/storage/providers/swarm/guides/index.md
+++ b/rif/storage/providers/swarm/guides/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: storage/providers/swarm/guides/index
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 WIP

--- a/rif/storage/providers/swarm/guides/local-network-incentives.md
+++ b/rif/storage/providers/swarm/guides/local-network-incentives.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Running a local Swarm network on RSK
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This guide sets up 2 Swarm nodes in a local private network. Each of the nodes is loaded into a specific directory; i.e. the folders `./s1` and `./s2`.

--- a/rif/storage/providers/swarm/guides/local-network.md
+++ b/rif/storage/providers/swarm/guides/local-network.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Running a local Swarm network
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 This guide sets up 2 Swarm nodes in a local private network. Each of the nodes is loaded into a specific directory; i.e. the folders `./s1` and `./s2`.

--- a/rif/storage/providers/swarm/incentives.md
+++ b/rif/storage/providers/swarm/incentives.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Swarm Incentives
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 File sharing systems heavily rely on users distributing files to others willingly. But strictly speaking, a user could choose to download a file and consume resources without uploading in return.

--- a/rif/storage/providers/swarm/index.md
+++ b/rif/storage/providers/swarm/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: About Swarm
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 Swarm is a censorship resistant, permissionless, decentralised storage and communication infrastructure.

--- a/rif/storage/providers/swarm/install.md
+++ b/rif/storage/providers/swarm/install.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Installing Swarm
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 To install Swarm, you can download the latest binaries or—alternatively—compile them directly from the source code.

--- a/rif/storage/providers/swarm/run.md
+++ b/rif/storage/providers/swarm/run.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Running Swarm for the first time
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## 1. Check the `swarm` command is in the PATH

--- a/rif/storage/providers/swarm/testnet-network.md
+++ b/rif/storage/providers/swarm/testnet-network.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Connecting to testnet Swarm network
+tags: rif, rif-storage, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## What is the RIF Storage testnet

--- a/roadmap/improvement-proposals.md
+++ b/roadmap/improvement-proposals.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Improvement Proposals
+tags: rskip, improvement, proposal, rsk, rbtc, rif, sk-improvement-proposal, roadmap, github, rbtc, defi, decentralized
 ---
 
 ## RSKIP - RSK Improvement Proposals

--- a/solutions/index.md
+++ b/solutions/index.md
@@ -1,6 +1,9 @@
 ---
 layout: rsk
 title: Solutions on RSK
+description: 'Check out the many ways our partners leverage the RSK and RIF
+platforms and APIs to create innovative experiences.'
+tags: solutions, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, on-ramp, off-ramp, payments, crypto
 ---
 
 Check out the many ways our partners leverage the RSK and RIF

--- a/tools/explorer/index.md
+++ b/tools/explorer/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Explorer
+tags: overview, explorer, rsk, search, blocks, transactions, mainnet, tools
 ---
 
 ## Overview Of The Explorer

--- a/tools/faucet.md
+++ b/tools/faucet.md
@@ -1,10 +1,12 @@
 ---
 layout: rsk
 title: RSK Tesnet Faucet
+tags: faucet, rsk, testnet, address, wallet, tools
 ---
+
 ## RSK Tesnet Faucet
 
-RSK [Testne Faucet](https://faucet.testnet.rsk.co/) can provide you with small denomination RSK coins for Testnet after you input your wallet address and pass the CAPTCHA.
+RSK [Testnet Faucet](https://faucet.testnet.rsk.co/) can provide you with small denomination RSK coins for Testnet after you input your wallet address and pass the CAPTCHA.
 
 <div align="center"><img width="100%" src="/assets/img/faucet/faucet1.png" alt="overview of faucet"/></div>
 

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Tools
+tags: truffle, ganache, explorer, testnet, faucet, networks, deployment, gas-station, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, wallets
 ---
 
 <div id="stats-carousel" class="owl-carousel owl-theme">

--- a/tools/tokenbridge/contractaddresses.md
+++ b/tools/tokenbridge/contractaddresses.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Addresses and Links
+tags: defi, decentralized, token-bridge, tokens, addresses, bridge, multisig, federation, powpeg, quick-start, guides, tutorial, testnet, faucet, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, sidechain, contracts, wallets
 ---
 
 # MainNet Addresses and Links

--- a/tools/tokenbridge/dappguide.md
+++ b/tools/tokenbridge/dappguide.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Token Bridge Dapp Guide
+tags: defi, decentralized, token-bridge, tokens, quick-start, testnet, networks, dapps, tools, rsk, ethereum, smart-contracts, guides, tutorial, install, get-started, how-to
 ---
 
 This Decentralized Application helps you to interact with the Token Bridge contracts, to safely cross your tokens between RSK and Ethereum networks. It is available at [tokenbridge.rsk.co](https://tokenbridge.rsk.co/) for mainnet or [testnet.tokenbridge.rsk.co](https://testnet.tokenbridge.rsk.co/) for testnet.

--- a/tools/tokenbridge/faq.md
+++ b/tools/tokenbridge/faq.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Token Bridge FAQ
+tags: faqs, defi, rbtc, decentralized, token-bridge, tokens, quick-start, guides, tutorial, testnet, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, sidechain, contracts, wallets
 ---
 
 ## What is the Token Bridge?

--- a/tools/tokenbridge/index.md
+++ b/tools/tokenbridge/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RSK <-> ETH Token Bridge
+tags: faqs, defi, decentralized, token-bridge, tokens, quick-start, guides, tutorial, testnet, networks, dapps, tools, rsk, ethereum, eth, rbtc, smart-contracts, install, get-started, how-to, mainnet, testnet, sidechain, contracts, wallets, swaps
 ---
 
 Ethereum/RSK Bridge that allows to move ERC20 tokens between one chain and the other.

--- a/tools/tokenbridge/usingmycrypto.md
+++ b/tools/tokenbridge/usingmycrypto.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Interaction guide using MyCrypto
+tags: mycrypto, defi, node, rbtc, ganache, decentralized, token-bridge, tokens, quick-start, guides, tutorial, testnet, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, sidechain, contracts, wallets
 ---
 
 This guide describes the necessary steps to perform a token transfer between two blockchain networks, which we will refer to to as **Mainchain** and **Sidechain**, through interaction with special contracts that make up a subsystem called **TokenBridge**.

--- a/tools/truffle/boxes.md
+++ b/tools/truffle/boxes.md
@@ -1,6 +1,8 @@
 ---
 layout: rsk
 title: Truffle Boxes
+description: 'How to setup your system to use a Truffle box'
+tags: truffle, ganache, quick-start, dapps, start-box, truffle-boxes, open zeppelin, testing, networks, deployment, npm, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, guides, tutorial
 ---
 
 To use most Truffle commands, you need to run them against an existing Truffle project. So the first step is to create a Truffle project.

--- a/tools/truffle/boxes/rsk-starter-box.md
+++ b/tools/truffle/boxes/rsk-starter-box.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: RSK starter box
+tags: truffle, ganache, quick-start, dapps, rsk-starter-box, truffle-boxes, open zeppelin, testing, networks, deployment, npm, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, guides, tutorial
 ---
 
 # RSK Truffle Starter Box

--- a/tools/truffle/ganache.md
+++ b/tools/truffle/ganache.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Ganache
+tags: ganache, tools, rsk, ethereum, smart-contracts, truffle, windows, mac, linux, get-started, how-to
 ---
 
 <style>

--- a/tools/truffle/index.md
+++ b/tools/truffle/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Truffle Overview
+tags: truffle, ganache, quick-start, truffle-boxes, open zeppelin, testing, networks, deployment, npm, tools, rsk, ethereum, smart-contracts, install, windows, mac, linux, get-started, how-to
 ---
 
 Truffle is a world class development environment, testing framework and asset pipeline for blockchains, aiming to make life as a developer easier. With Truffle, you get:

--- a/tutorials/compile-smart-contracts-go.md
+++ b/tutorials/compile-smart-contracts-go.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Compile Smart Contracts to Go
+tags: go, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ###### (instructions valid for Ubuntu) 

--- a/tutorials/deploy-smart-contracts.md
+++ b/tutorials/deploy-smart-contracts.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Deploy Smart Contracts
+tags: rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 <style>

--- a/tutorials/interact-with-smart-contracts.md
+++ b/tutorials/interact-with-smart-contracts.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Interact with Smart Contracts
+tags: rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Interaction with the Contract

--- a/tutorials/interface-registry.md
+++ b/tutorials/interface-registry.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Universal Smart Contract Interface Registry
+tags: interface, registry, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The ERC1820 standard defines a universal registry smart contract where any address (contract or regular account) can register which interface it supports and which smart contract is responsible for its implementation.

--- a/tutorials/send-tokens-through-metamask.md
+++ b/tutorials/send-tokens-through-metamask.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Send RIF Tokens through Metamask
+tags: tokens, metamask, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Send RIF Tokens through Metamask

--- a/tutorials/using-blockmason.md
+++ b/tutorials/using-blockmason.md
@@ -2,6 +2,7 @@
 layout: rsk
 title: Blockmason
 description: "How to use RSK with Blockmason Link, with an example of deploying a smart contract to the Testnet"
+tags: block-mason, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Using RSK with Blockmason Link

--- a/wallet/index.md
+++ b/wallet/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Wallets
+tags: rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## Use a wallet

--- a/wallet/use/index.md
+++ b/wallet/use/index.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Wallets
+tags: rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 The following wallets support [RBTC](/rsk/rbtc/) and [RIF](/rif/token) tokens, check [how to use it](#how-to-use) with the tutorials below:

--- a/wallet/use/json-rpc.md
+++ b/wallet/use/json-rpc.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: JSON-RPC
+tags: json-rpc, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 In order to use JSON-RPC, you should have an RSK node running. Additionally, ensure that your node has enabled the `personal` module in the config file, as the `personal.newAccount` method will be used.

--- a/wallet/use/ledger.md
+++ b/wallet/use/ledger.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Ledger App
+tags: json-rpc, ledger, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 # RSK App in Ledger

--- a/wallet/use/metamask.md
+++ b/wallet/use/metamask.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: MetaMask
+tags: json-rpc, metamask, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 For MetaMask installation, please <a href="https://metamask.io/" target="_blank">visit here</a>.

--- a/wallet/use/mycrypto.md
+++ b/wallet/use/mycrypto.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: MyCrypto
+tags: mycrypto, json-rpc, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RSK With MyCrypto

--- a/wallet/use/myetherwallet.md
+++ b/wallet/use/myetherwallet.md
@@ -1,4 +1,5 @@
 ---
 layout: rsk
 title: MyEtherWallet
+tags: mew, myetherwallet, json-rpc, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---

--- a/wallet/use/nifty.md
+++ b/wallet/use/nifty.md
@@ -1,6 +1,7 @@
 ---
 layout: rsk
 title: Nifty
+tags: nifty, json-rpc, rif, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 # How To Create A Nifty Wallet
 


### PR DESCRIPTION
## What
- work out which files do not have tags but should
-- see references below for preliminary search using `grep`
-- from this list only use a subset which aren't redirects or markdown files that aren't published
- add appropriate tags to all of the markdown files for these pages

## Why
- UX improvement identified during user testing of devportal
- better search results

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-137?atlOrigin=eyJpIjoiNGViMWFmYmU3M2RjNDQxMTlhYjUxMDA4ZmQzMGM5MTgiLCJwIjoiaiJ9)
