### PR TITLE
Chore: Quick Fix based on User Testing Results

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -47,6 +47,7 @@
                 <a class="dropdown-item" href="/wallet/" target="_self">Wallets</a>
                 <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="https://www.rifos.org/nameservice/index">RIF Name Service</a>
                 <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="https://marketplace.rifos.org/">RIF Marketplace</a>
+                <a target="_blank" rel="noopener noreferrer" class="dropdown-item" href="/rsk/rbtc/#exchanges">Buy RBTC/RIF Tokens</a>
             </div>
         </li>
         <li class="nav-item dropdown">

--- a/_rsk/rbtc/index.md
+++ b/_rsk/rbtc/index.md
@@ -85,6 +85,11 @@ See [supported wallets](/wallet/use/).
 
 ## Exchanges
 
+Looking for [RIF Token](/rif/token/)?
+
+You can purchase the RIF Token using the [exchanges](/rif/token/#exchanges) listed here,
+or use the exchanges listed below👇 to buy RBTC.
+
 <div class="owl-carousel owl-theme">
     <div class="item">
         <a href="https://www.liquid.com/" target="blank">

--- a/_rsk/rbtc/index.md
+++ b/_rsk/rbtc/index.md
@@ -87,8 +87,8 @@ See [supported wallets](/wallet/use/).
 
 Looking for [RIF Token](/rif/token/)?
 
-You can purchase the RIF Token using the [exchanges](/rif/token/#exchanges) listed here,
-or use the exchanges listed below👇 to buy RBTC.
+You can obtain the RIF Token using [these exchanges](/rif/token/#exchanges),
+or use the exchanges listed below👇 to obtain RBTC.
 
 <div class="owl-carousel owl-theme">
     <div class="item">

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ The Developer Portal is the home for RSK documentation for end users and develop
     <ul id="card-list" class="row">
         <li class="col-xl-6 col-md-6">
         <div class="feature-card">
-            <a href="/guides/quick-start/">
+            <a href="/guides/quickstart/">
             <div class="icon started h-100">
             <div class="icon-cont text-center my-auto">
             <img src="/assets/img/features/started-icon.png" alt="started icon">

--- a/index.md
+++ b/index.md
@@ -10,19 +10,19 @@ The Developer Portal is the home for RSK documentation for end users and develop
     <ul id="card-list" class="row">
         <li class="col-xl-6 col-md-6">
         <div class="feature-card">
-            <a href="/quick-start">
+            <a href="/guides/quick-start/">
             <div class="icon started h-100">
             <div class="icon-cont text-center my-auto">
             <img src="/assets/img/features/started-icon.png" alt="started icon">
             </div>
             </div>
-            </a><div class="content"><a href="/quick-start">
+            </a><div class="content"><a href="/guides/quickstart/">
             <div class="content-container">
                 <p class="card-title rsk_green">Getting Started</p>
                 <p class="card-desc">SmartBitcoin (RBTC) is linked 1:1 to Bitcoin (1 RBTC = 1 BTC)</p>
             </div>
-            </a><div class="btn-container "><a href="/quick-start">
-                </a><a class="green" href="/quick-start">Read More</a>
+            </a><div class="btn-container "><a href="/guides/quickstart/">
+                </a><a class="green" href="/guides/quickstart/">Read More</a>
             </div>
             </div>
         </div>

--- a/rif/token.md
+++ b/rif/token.md
@@ -82,10 +82,10 @@ See [supported wallets](/wallet/use/).
 
 ## Exchanges
 
-Looking for [RBTC Cryptocurrency](/rsk/rbtc/)?
+Looking for [RBTC](/rsk/rbtc/)?
 
-You can purchase the RBTC cryptocurrency using the [exchanges](/rsk/rbtc/#exchanges) listed here,
-or use the exchanges listed below👇 to buy the RIF token.
+You can obtain RBTC using [these exchanges](/rsk/rbtc/#exchanges),
+or use the exchanges listed below👇 to obtain the RIF token.
 
 <div class="owl-carousel owl-theme">
   <div class="item" style="width: 275px;">

--- a/rif/token.md
+++ b/rif/token.md
@@ -82,6 +82,11 @@ See [supported wallets](/wallet/use/).
 
 ## Exchanges
 
+Looking for [RBTC Cryptocurrency](/rsk/rbtc/)?
+
+You can purchase the RBTC cryptocurrency using the [exchanges](/rsk/rbtc/#exchanges) listed here,
+or use the exchanges listed below👇 to buy the RIF token.
+
 <div class="owl-carousel owl-theme">
   <div class="item" style="width: 275px;">
     <div class="item">


### PR DESCRIPTION
## What

- Replaced the quick start link on the homepage with the update link ASAP
- Reviewed the top menu to add links to RBTC page and RIF token page
- Updated links to look for other assets In both RBTC page and the RIF token page
- Added to the exchanges section a 1-liner description to make the above connection explicit

## Why

- Quick fix based on User Testing 
- Docs maintenance

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-141?atlOrigin=eyJpIjoiOTBlNDFiODQ2NThkNGU0YmE5MDVhNjY1ZjZkNGVhNmMiLCJwIjoiaiJ9)
