### PR TITLE
fix: reposition videos translations

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -619,14 +619,7 @@
         <a href="/solutions/">Solutions</a>
         <ul>
           <li class="hide-mobile"><a href="/solutions/">Solutions on RSK</a></li>
-          <li>
-            <span class="fa fa-chevron-right"></span>
-            <a href="/solutions/defiant/">Defiant</a>
-            <ul>
-              <a href="/solutions/defiant/">Defiant</a>
-              <li><a href="/solutions/defiant/tagalog/">Tagalog</a></li>
-            </ul>
-          </li>
+          <li><a href="/solutions/defiant/">Defiant</a></li>
           <li><a href="/solutions/chainbeat/">Chainbeat</a></li>
           <li><a href="/solutions/moneyonchain/">Money on Chain</a></li>
           <li><a href="/solutions/oraclemoneyonchain/">Oracle Money on Chain</a></li>
@@ -638,14 +631,7 @@
           <li><a href="/solutions/chainlink/">Chainlink</a></li>
           <li><a href="/solutions/edge/">Edge</a></li>
           <li><a href="/solutions/tenderly/">Tenderly</a></li>
-          <li>
-            <span class="fa fa-chevron-right"></span>
-            <a href="/solutions/kriptonmarket/">Kripton Market</a>
-            <ul>
-              <a href="/solutions/kriptonmarket/">Kripton Market</a>
-              <li><a href="/solutions/kriptonmarket/tagalog/">Tagalog</a></li>
-            </ul>
-          </li>
+          <li><a href="/solutions/kriptonmarket/">Kripton Market</a></li>
           <li><a href="/solutions/sovryn/">Sovryn</a></li>
         </ul>
       </li> <!-- /Solutions -->

--- a/kb/get-crypto-on-rsk/cryptocurrency-vs-token.md
+++ b/kb/get-crypto-on-rsk/cryptocurrency-vs-token.md
@@ -7,6 +7,10 @@ layout: 'rsk'
 
 ![CryptovsTokenBanner](/assets/img/kb/get-crypto-on-rsk/crypto-token-banner.jpg)
 
+<div class="video-container">
+  <iframe width="949" height="534" src="https://www.youtube.com/embed/GWoNxoaIsbQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 ## What is a Digital Asset?
 
 In broad terms, a digital asset is a non-tangible asset that is created, traded, and stored in a digital format. Using this definition, in the context of blockchains, digital assets include cryptocurrency and crypto tokens.
@@ -57,16 +61,8 @@ When interacting with blockchain networks, it is important to be aware of this d
 
 > Note that when talking about tokens, you will see the terms ERC-20 as well as EIP-20. These are both **the same**. At the outset, the process for defining standards for Ethereum, and Ethereum-compatible networks, was called “Ethereum Request for Comment”. This process has since been refined and renamed to “Ethereum Improvement Proposal”.
 
-## Explainer video
-
-Watch this short explainer video on the difference between a Cryptocurrency and a Token to gain a better understanding.
-
-<div class="video-container">
-  <iframe width="949" height="534" src="https://www.youtube.com/embed/GWoNxoaIsbQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
 ## Next
 
-Be sure to check out our next article in this series, 
-about how to get the RSK cryptocurrency, RBTC, 
+Be sure to check out our next article in this series,
+about how to get the RSK cryptocurrency, RBTC,
 by using the PowPeg: [How to get RBTC using RSK’s built in PowPeg](/kb/get-crypto-on-rsk/powpeg-btc-rbtc/)

--- a/kb/get-crypto-on-rsk/powpeg-btc-rbtc.md
+++ b/kb/get-crypto-on-rsk/powpeg-btc-rbtc.md
@@ -7,16 +7,20 @@ layout: "rsk"
 
 ![Powpeg Banner](/assets/img/kb/get-crypto-on-rsk/powpeg-banner.jpg)
 
+<div class="video-container">
+  <iframe width="949" height="534" src="https://www.youtube.com/embed/KmXayl_z9-0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 If you want to get RBTC,
 there are a number of different ways to do it,
 ranging from exchanges, decentralised exchanges,
 and even peer-to-peer swaps -
-These are generally easier to use. 
+These are generally easier to use.
 
 The RSK blockchain protocol itself supports a method built into its
 blockchain protocol that allows for two-way swaps between BTC and RBTC:
 The RSK PowPeg.
-This is generally more difficult to use, 
+This is generally more difficult to use,
 and is intended for those with a more technical background.
 
 Even if you intend to use those other services to obtain RBTC,
@@ -32,7 +36,7 @@ It requires low third party trust.
 
 In the case of RSK, the main blockchain is Bitcoin,
 and the secondary blockchain is RSK.
-Every RBTC (or fraction of RBTC) unlocked in the RSK platform 
+Every RBTC (or fraction of RBTC) unlocked in the RSK platform
 requires BTC to be locked on the Bitcoin blockchain.
 This mechanism ensures there is a one-to-one relationship
 between BTC and RBTC (1 BTC = 1 RBTC),
@@ -43,15 +47,6 @@ they need to send the cryptocurrency to the address
 specified by the PowPeg,
 triggering a peg-in or a peg-out,
 which we will describe in more detail below.
-
-**Explainer video**
-
-Watch this short explainer video to know more about the Powpeg;
-
-<div class="video-container">
-  <iframe width="949" height="534" src="https://www.youtube.com/embed/KmXayl_z9-0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
 
 ## How the RSK PowPeg works
 
@@ -70,13 +65,13 @@ so that both accounts are controlled by the same private key.
 > Note that in the upcoming RSK release (IRIS-3.0),
 > this is partially changing.
 > The PowPeg will allow the user to specify the
-> receiving address for peg-ins (BTC → RBTC). 
+> receiving address for peg-ins (BTC → RBTC).
 
 The process of peg-ins and peg-outs are done completely using
 Bitcoin wallet software and RSK wallet software.
 The onus to perform the necessary checks and validations
 for compliance with the rules of the PowPeg lies on the user,
-as there is no application or tool to perform this. 
+as there is no application or tool to perform this.
 
 > Warning: The user needs to be aware of this lack of “guard rails”,
 > and accept the risk that transactions may be rejected
@@ -134,7 +129,7 @@ bitcoins from the RSK network to the Bitcoin network.
 To perform peg-outs, send the bitcoins (RBTC) to the Bridge.
 Then wait for the required number of confirmation blocks,
 after which the Bridge builds the transaction
-to release bitcoins (BTC) on the Bitcoin network. 
+to release bitcoins (BTC) on the Bitcoin network.
 
 ![Peg-Out](/assets/img/kb/get-crypto-on-rsk/RSK-Bitcoin-Peg-Out.gif)
 
@@ -159,6 +154,6 @@ between BTC and RBTC using the PowPeg protocol.
 
 ## Next
 
-Be sure to check out our next article in this series, 
-about how to get the RSK cryptocurrency, RBTC, 
+Be sure to check out our next article in this series,
+about how to get the RSK cryptocurrency, RBTC,
 by using wallets: [How to get RBTC using Wallets](/kb/get-crypto-on-rsk/rbtc-wallets/)

--- a/solutions/defiant/index.md
+++ b/solutions/defiant/index.md
@@ -12,7 +12,7 @@ You can store, send and exchange crypto in an agile and secure way, without inte
 
 ![Defiant Banner](/assets/img/solutions/defiant/banner_rsk2.jpg)
 
-[Translated in Tagalog](/solutions/defiant/tagalog/)
+> This page is available in: [English](/solutions/defiant/) | [Tagalog (🇵🇭)](/solutions/defiant/tagalog/)
 
 Watch these short explainer videos:
 
@@ -103,4 +103,4 @@ Defiant is your door into this new world and the new ones to come.
 - [Instagram](https://instagram.com/defiant_app)
 - [Telegram](https://t.me/DefiantES)
 
-> See this page in [Tagalog](/solutions/defiant/tagalog/)
+> This page is available in: [English](/solutions/defiant/) | [Tagalog (🇵🇭)](/solutions/defiant/tagalog/)

--- a/solutions/defiant/tagalog.md
+++ b/solutions/defiant/tagalog.md
@@ -6,13 +6,15 @@ render_features: 'tables-with-borders'
 layout: "rsk"
 ---
 
-Ang Defiant ang unang platapormang mobil at peer-to-peer na merkado para sa stablecoins. 
+Ang Defiant ang unang platapormang mobil at peer-to-peer na merkado para sa stablecoins.
 
-Ang serbisyong ito ay nagpapahalintulot ng palitan ng cryptocurrencies mula sa mga sistema na Bitcoin, RSK at Ethereum gamit ang geolocation. 
+Ang serbisyong ito ay nagpapahalintulot ng palitan ng cryptocurrencies mula sa mga sistema na Bitcoin, RSK at Ethereum gamit ang geolocation.
 
-Maari kang magtago, magpadala at makipag-palit ng crypto sa mas mabilis at ligtas na paraan ng walang tagapamagitan. 
+Maari kang magtago, magpadala at makipag-palit ng crypto sa mas mabilis at ligtas na paraan ng walang tagapamagitan.
 
 ![Defiant Banner](/assets/img/solutions/defiant/banner_rsk2.jpg)
+
+> This page is available in: [English](/solutions/defiant/) | [Tagalog (🇵🇭)](/solutions/defiant/tagalog/)
 
 **Panuorin itong mga maiikling paliwanag na bidyo**:
 
@@ -33,7 +35,7 @@ Maari kang magtago, magpadala at makipag-palit ng crypto sa mas mabilis at ligta
 - [Android](https://play.google.com/store/apps/details?id=ar.com.andinasmart.defiant&hl=en)
 - [iOS](https://testflight.apple.com/join/nuboBx5F) (on Testflight)
 
-## Paano gamitin and Defiant 
+## Paano gamitin and Defiant
 
 - [English](https://defiantapp.tech/wp-content/uploads/2020/08/android_eng.pdf)
 - [Español](https://defiantapp.tech/wp-content/uploads/2020/07/Guia-Defiant-Android.pdf )
@@ -48,9 +50,9 @@ Maari mong i-access ang mga cryptocurrency at mga token sa network ng RSK gamit 
 
 ## Mga pangunahing katangian ng Defiant:
 
-- **Pagtugma**: Unang wallet na nagtatrabaho para sa Bitcoin, RSK at Ethereum. 
-- **Ligtas at walang tagapag-alaga**: Walang ibang mayroong access sa iyong crypto kung hindi ikaw lamang. Maari mo silang kunin kahit saan at kailan mo gustuhin. 
-- **Peer-to-peer na merkado**: Maari mo ipagpalit and crypto, peer to peer, mula sa app ng walang tagapamagitan. 
+- **Pagtugma**: Unang wallet na nagtatrabaho para sa Bitcoin, RSK at Ethereum.
+- **Ligtas at walang tagapag-alaga**: Walang ibang mayroong access sa iyong crypto kung hindi ikaw lamang. Maari mo silang kunin kahit saan at kailan mo gustuhin.
+- **Peer-to-peer na merkado**: Maari mo ipagpalit and crypto, peer to peer, mula sa app ng walang tagapamagitan.
 - **Matatag na coins**: Maari mong itago and cryptocurrencies sa pagkakapare-pareho nito sa dollar tulad ng Dollar on Chain (DOC) at DAI.
 - **DeFi**: Ang Defiant ay nagpapahintulot sa iyo na mamahala sa iyong pera sa paraang desetralisado at walang ibang tagapamahala. Kahit kami ay walang access sa iyong crypto.
 
@@ -90,10 +92,12 @@ Mga ilang taon lamang nang and blockchain ay sinimulan, para lutasan ang aspeton
 | [BTCX](https://explorer.rsk.co/address/0xf773b590af754d597770937fa8ea7abdf2668370) | [BTCX](https://moneyonchain.com/btcx-leveraged-bitcoin/) | RSK |
 | [RIFX](https://explorer.rsk.co/address/0xcff3fcaec2352c672c38d77cb1a064b7d50ce7e1) | [RIFX](https://rif.moneyonchain.com/metrics) | RSK |
 
-## Makipag-usap sa amin sa pamamagitan ng aming: 
+## Makipag-usap sa amin sa pamamagitan ng aming:
 
 - Website: [English](https://defiantapp.tech/home/), [Español](http://www.defiantapp.tech)
 - Twitter: [English](https://twitter.com/@defiantapp_EN), [Español](https://twitter.com/@defiantapp)
 - [Facebook](https://facebook.com/defiantapp)
 - [Instagram](https://instagram.com/defiant_app)
 - [Telegram](https://t.me/DefiantES)
+
+> This page is available in: [English](/solutions/defiant/) | [Tagalog (🇵🇭)](/solutions/defiant/tagalog/)

--- a/solutions/kriptonmarket/index.md
+++ b/solutions/kriptonmarket/index.md
@@ -12,7 +12,7 @@ Kripton integrates with RSK to provide an on/off ramp solution to give users in 
 
 ![Kripton-banner-image](/assets/img/solutions/kriptonmarket/kripton-banner.jpg)
 
-[Translated in Tagalog](/solutions/kriptonmarket/tagalog/)
+> This page is available in: [English](/solutions/kriptonmarket/) | [Tagalog (🇵🇭)](/solutions/kriptonmarket/tagalog/)
 
 ## Integration with RSK
 
@@ -30,7 +30,7 @@ Kripton integrates with RSK to provide an on/off ramp solution to give users in 
 
 - Argentina 🇦🇷
 - Venezuela 🇻🇪
-- Colombia 🇨🇴 
+- Colombia 🇨🇴
 - Peru 🇵🇪
 - Uruguay 🇺🇾
 
@@ -103,4 +103,4 @@ Kripton integrates with RSK to provide an on/off ramp solution to give users in 
 - [Twitter](https://twitter.com/Kriptonmarket)
 - [Telegram](https://t.me/kriptonmarket)
 
-> See this page in [Tagalog](/solutions/kriptonmarket/tagalog/)
+> This page is available in: [English](/solutions/kriptonmarket/) | [Tagalog (🇵🇭)](/solutions/kriptonmarket/tagalog/)

--- a/solutions/kriptonmarket/tagalog.md
+++ b/solutions/kriptonmarket/tagalog.md
@@ -10,10 +10,11 @@ Ang Kripton ay nagnanais na magpaunlad ng bagong ekonomiya:
 Dinamika, desentralisado, ligtas at mapagkakakitaan.
 
 Ang Kripton ay kasama ng RSK ay nakikipag-ugnayan para magbahagi
-ng **on o off na ramp solution** para bigyan ang mga gumagamit nito sa mga bansa sa Latin Amerika ng access sa cryptocurrencies at tokens sa RSK network gamit ang local na pera.  
-
+ng **on o off na ramp solution** para bigyan ang mga gumagamit nito sa mga bansa sa Latin Amerika ng access sa cryptocurrencies at tokens sa RSK network gamit ang local na pera.
 
 ![Kripton-banner-image](/assets/img/solutions/kriptonmarket/kripton-banner.jpg)
+
+> This page is available in: [English](/solutions/kriptonmarket/) | [Tagalog (🇵🇭)](/solutions/kriptonmarket/tagalog/)
 
 ## Pakikipag-ugnayan sa RSK
 
@@ -21,17 +22,17 @@ ng **on o off na ramp solution** para bigyan ang mga gumagamit nito sa mga bansa
 
 ## Mga Feature:
 
-- Pagsama ng sistema ng wire transfer gamit ang local na pera sa mga selektadong bansa sa Latin Amerika. 
+- Pagsama ng sistema ng wire transfer gamit ang local na pera sa mga selektadong bansa sa Latin Amerika.
 - Pakikipag-ugnayan sa Bitcoin network upang makapagbigay ng access sa BTC.
-- Pakikipag-ugnayan kasama ng network ng RSK para makapagbigay ng access sa RBTC at ilang token na base sa RSK. 
-- Pakikipag-ugnayan sa network ng Ethereum para makapagbigay ng access sa ilang mga token na base sa Ethereum. 
-- Pakikipag-ugnayan sa mga selektadong pitaka ng RSK para makapagbigay ng maayos na paraan upang makipag-palitan ng lokal na pera at crypto. Sa kasalukuyan: [Defiant](/solutions/defiant) 
+- Pakikipag-ugnayan kasama ng network ng RSK para makapagbigay ng access sa RBTC at ilang token na base sa RSK.
+- Pakikipag-ugnayan sa network ng Ethereum para makapagbigay ng access sa ilang mga token na base sa Ethereum.
+- Pakikipag-ugnayan sa mga selektadong pitaka ng RSK para makapagbigay ng maayos na paraan upang makipag-palitan ng lokal na pera at crypto. Sa kasalukuyan: [Defiant](/solutions/defiant)
 
 ## Mga suportadong bansa
 
 - Argentina🇦🇷
 - Venezuela🇻🇪
-- Colombia🇨🇴 
+- Colombia🇨🇴
 - Peru🇵🇪
 - Uruguay🇺🇾
 
@@ -80,7 +81,7 @@ ng **on o off na ramp solution** para bigyan ang mga gumagamit nito sa mga bansa
 
 - Mahigit-kumulang ±3% buy and sell
 
-Tignan ang mga rate para sa: 
+Tignan ang mga rate para sa:
 
 - Argentina: [ARS](https://kriptonmarket.com/cotizacion?currency=ars)
 - Uruguay: [UYU](https://kriptonmarket.com/cotizacion?currency=uyu)
@@ -88,7 +89,7 @@ Tignan ang mga rate para sa:
 - Colombia: [COP](https://kriptonmarket.com/cotizacion?currency=col)
 - Peru: [PEN](https://kriptonmarket.com/cotizacion?currency=pen)
 
-### Mga limitasyon 
+### Mga limitasyon
 - Limit ng deposit: 2000 USD kada-buwan o 4000 USD kada taon.
 - Limit ng pag-withdraw: Walang limit.
 
@@ -109,3 +110,5 @@ Tignan ang mga rate para sa:
 
 - [Twitter](https://twitter.com/Kriptonmarket)
 - [Telegram](https://t.me/kriptonmarket)
+
+> This page is available in: [English](/solutions/kriptonmarket/) | [Tagalog (🇵🇭)](/solutions/kriptonmarket/tagalog/)


### PR DESCRIPTION
## What

- move each explainer videos to the top of its page (rbtc series)
- remove translation links from nav menu
- standardise translations links within each page

## Why

- improve reader experience

## Refs

- nil
