### PR TITLE
Removing prune documentation

### DIFF
--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -42,7 +42,6 @@ The following detail the most commonly used configuration fields parsed by RSKj.
 - [`hello.phrase`](#hellophrase)
 - [`details.inmemory.storage.limit`](#detailsinmemorystoragelimit)
 - [`solc.path`](#solcpath)
-- [`prune`](#prune)
 
 ## peer
 
@@ -399,37 +398,3 @@ only deltas are saved.
 The path to the [Solidity](http://solidity.readthedocs.io) compiler.
 This is set when you may want to use the node to compile your smart contracts.
 If you don't have Solidity installed, you can use `/bin/false` as value.
-
-## prune
-
-The prune service is a process that runs over the node storage to lighten the space it needs to be synchronized.
-This process removes useless data over a determined amount of blocks processed.
-
-To enable the prune service in your node, override your configuration.
-
-These are the recommended parameters:
-
-```
-prune {
-    # prune service could be enabled or not
-    # values: [true/false]
-    # default: false
-    enabled = true
-
-    # Number of blocks to process
-    blocks {
-        # Number of blocks to copy in each prune run
-        # default: 5000
-        toCopy = 5000
-
-        # Number of blocks to wait to run prune again
-        # default: 10000
-        toWait = 10000
-
-        # Number of blocks to suspend blockchain process
-        # in order to avoid forks
-        # default: 100
-        toAvoidForks = 100
-    }
-}
-```

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -83,37 +83,6 @@ module.exports = {
 };
 ```
 
-### The node takes up too much space
-
-The prune service is a process that runs over the node storage to lighten the space it needs to be synchronized. This process removes useless data over a determined amount of blocks processed.
-
-To enable prune service in your node [override your configuration](/rsk/node/configure). These are the recommended parameters:
-
-```
-prune {
-    # prune service could be enabled or not
-    # values: [true/false]
-    # default: false
-    enabled = true
-
-    # Number of blocks to process
-    blocks {
-        # Number of blocks to copy in each prune run
-        # default: 5000
-        toCopy = 5000
-
-        # Number of blocks to wait to run prune again
-        # default: 10000
-        toWait = 10000
-
-        # Number of blocks to suspend blockchain process
-        # in order to avoid forks
-        # default: 100
-        toAvoidForks = 100
-    }
-}
-```
-
 ### Can't get public IP
 
 If you get the error:

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -16,7 +16,6 @@ If what you need is not in this section, **please contact us** without hesitatio
 - ['I don't see the logs'](#i-dont-see-the-logs)
 - ['Plugin with id 'witness' not found'](#plugin-with-id-witness-not-found)
 - ['Truffle doesn't seem to work connected to RSK'](#truffle-doesnt-seem-to-work-connected-to-rsk)
-- ['The node takes up too much space'](#the-node-takes-up-too-much-space)
 - ['Can't get public IP'](#cant-get-public-ip)
 
 ## Sections


### PR DESCRIPTION
## What

- Removing references to the "prune" feature, since [it was removed](https://github.com/rsksmart/rskj/commit/8b027829787db89847c5bebca1acc28000b8a4e7) a long time ago.

## Why

- Feature is no longer part of the RSK Node.
- It [has generated some confusion](https://github.com/rsksmart/rskj/issues/1555) within some of our users.

## Refs

- [Jira Ticket](https://rsklabs.atlassian.net/jira/software/projects/CORE/boards/59?selectedIssue=CORE-523)
- [Reported Issue](https://github.com/rsksmart/rskj/issues/1555)
