### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ bundle exec jekyll -v
 None of these three commands should error,
 and they should all print out their version numbers.
 
+> For Mac M1, open Terminal using Rosetta. Ref: https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/
+
 ## Usage
 
 ### Production build


### PR DESCRIPTION
## What

- Describe how to run using a Mac with new M1

## Why

- Running "normally" throws an error installing `nokogumbo`, dependency of `html-proofer`

