### PR TITLE
Docs: Updated RSKj from Papyrus 2.2.0 to IRIS 3.0.0

### DIFF
--- a/_rsk/node/configure/verbosity.md
+++ b/_rsk/node/configure/verbosity.md
@@ -120,7 +120,7 @@ A logback configuration example can be downloaded from [here](https://github.com
 If you're running a node [using the release jar file](/rsk/node/install/java) use the following command:
 
 ```bash
-java -cp rskj-core-2.2.0-PAPYRUS-all.jar -Dlogback.configurationFile=/full/path/to/logback.xml co.rsk.Start
+java -cp rskj-core-3.0.0-IRIS-all.jar -Dlogback.configurationFile=/full/path/to/logback.xml co.rsk.Start
 ```
 
 #### Using logback with a compiled node

--- a/_rsk/node/contribute/linux.md
+++ b/_rsk/node/contribute/linux.md
@@ -37,7 +37,7 @@ Run these commands on Git command line:
 ```shell
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
-git checkout tags/PAPYRUS-2.2.0 -b PAPYRUS-2.2.0
+git checkout tags/IRIS-3.0.0 -b IRIS-3.0.0
 ```
 
 *Note:* It is better to download the code into a short path.

--- a/_rsk/node/contribute/macos.md
+++ b/_rsk/node/contribute/macos.md
@@ -49,7 +49,7 @@ Run these commands on Git command line:
 ```
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
-git checkout tags/PAPYRUS-2.2.0 -b PAPYRUS-2.2.0
+git checkout tags/IRIS-3.0.0 -b IRIS-3.0.0
 ```
 
 *Note:* It is better to download the code into a short path.

--- a/_rsk/node/install/java.md
+++ b/_rsk/node/install/java.md
@@ -26,7 +26,7 @@ To run the node:
   C:\> java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
   ```
 
-Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-2.2.0-PAPYRUS-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-3.0.0-IRIS-all.jar`
 
 ## Using import sync
 
@@ -67,7 +67,7 @@ to change the memory allocated to the process:
   C:\> java -Xmx4G -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
   ```
 
-Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-2.2.0-PAPYRUS-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-3.0.0-IRIS-all.jar`
 
 For further reference, check out the
 [`database.import` configuration setting](/rsk/node/configure/reference/#databaseimport).
@@ -102,7 +102,7 @@ If you want to change the network use these commands:
 - Testnet: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --testnet`
 - Regtest: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --regtest`
 
-Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-2.2.0-PAPYRUS-all.jar`
+Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-3.0.0-IRIS-all.jar`
 
 ## Video
 

--- a/_rsk/node/install/ubuntu.md
+++ b/_rsk/node/install/ubuntu.md
@@ -33,7 +33,7 @@ Choose `mainnet` and press `Enter` to continue
 
 ## Install via Direct Downloads
 
-You can also download the RSKj Ubuntu Package for Papyrus 2.2.0 and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
+You can also download the RSKj Ubuntu Package for Iris 3.0.0 and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
 
 ```shell
 # first install openjdk-8-jre or oracle-java8-installer

--- a/_rsk/node/reproducible.md
+++ b/_rsk/node/reproducible.md
@@ -51,9 +51,9 @@ RUN apt-get update -y && \
     apt-get clean
 RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
 RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
-RUN git clone --single-branch --depth 1 --branch PAPYRUS-2.2.0 https://github.com/rsksmart/rskj.git /code/rskj
+RUN git clone --single-branch --depth 1 --branch IRIS-3.0.0 https://github.com/rsksmart/rskj.git /code/rskj
 RUN git clone https://github.com/rsksmart/reproducible-builds 
-RUN CP /Users/{$USER}/reproducible-builds/rskj/2.2.0-papyrus/Dockerfile  /Users/{$USER}/code/rskj
+RUN CP /Users/{$USER}/reproducible-builds/rskj/3.0.0-iris/Dockerfile  /Users/{$USER}/code/rskj
 WORKDIR /code/rskj
 RUN gpg --verify SHA256SUMS.asc
 RUN sha256sum --check SHA256SUMS.asc
@@ -69,9 +69,9 @@ brew install git gnupg openjdk@8 && \
     brew cleanup
 RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
 RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
-RUN git clone --single-branch --depth 1 --branch PAPYRUS-2.2.0 https://github.com/rsksmart/rskj.git ./code/rskj
+RUN git clone --single-branch --depth 1 --branch IRIS-3.0.0 https://github.com/rsksmart/rskj.git ./code/rskj
 RUN git clone https://github.com/rsksmart/reproducible-builds 
-RUN CP /Users/{$USER}/reproducible-builds/rskj/2.2.0-papyrus/Dockerfile  /Users/{$USER}/code/rskj
+RUN CP /Users/{$USER}/reproducible-builds/rskj/3.0.0-papyrus/Dockerfile  /Users/{$USER}/code/rskj
 RUN CD /code/rskj
 RUN gpg --verify SHA256SUMS.asc
 RUN sha256sum --check SHA256SUMS.asc
@@ -88,7 +88,7 @@ Run build
 To create a reproducible build, run:
 
 ```bash
-sudo docker build -t rskj-papyrus-2.2.0-reproducible .
+sudo docker build -t rskj-iris-3.0.0-reproducible .
 ```
 
 This may take several minutes to complete. What is done is:
@@ -101,7 +101,7 @@ This may take several minutes to complete. What is done is:
 To obtain SHA-256 checksums, run the following command:
 
 ```bash
-sudo docker run --rm rskj-papyrus-2.2.0-reproducible sha256sum /code/rskj/rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS-all.jar /code/rskj/rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS-sources.jar /code/rskj/rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS.jar /code/rskj/rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS.pom
+sudo docker run --rm rskj-iris-3.0.0-reproducible sha256sum /code/rskj/rskj-core/build/libs/rskj-core-3.0.0-IRIS-all.jar /code/rskj/rskj-core/build/libs/rskj-core-3.0.0-IRIS-sources.jar /code/rskj/rskj-core/build/libs/rskj-core-3.0.0-IRIS.jar /code/rskj/rskj-core/build/libs/rskj-core-3.0.0-IRIS.pom
 ```
 
 Check Results
@@ -111,10 +111,10 @@ After running the build process, a JAR file will be created in ```/code/rskj-cor
 You can check the SHA256 sum of the result file and compare it to the one published by RSK for that version.
 
 ```bash
-f7cb1e6c5568332d047c602a5b2c464c41688336b824d92ef3a40b89a8f55b60  rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS-all.jar
-751d87b110205357478a9bd7909413bf80afacd51bd10eaa502bec50fda5a410  rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS-sources.jar
-d2f6594272748de21f70025e59525f2ffc6159ce21b6751590c3b535953c4d29  rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS.jar
-7204272b35891dca1d962af811dec92889d9564e5b200b5a50485101557e2f36  rskj-core/build/libs/rskj-core-2.2.0-PAPYRUS.pom
+f7cb1e6c5568332d047c602a5b2c464c41688336b824d92ef3a40b89a8f55b60  rskj-core/build/libs/rskj-core-3.0.0-IRIS-all.jar
+751d87b110205357478a9bd7909413bf80afacd51bd10eaa502bec50fda5a410  rskj-core/build/libs/rskj-core-3.0.0-IRIS-sources.jar
+d2f6594272748de21f70025e59525f2ffc6159ce21b6751590c3b535953c4d29  rskj-core/build/libs/rskj-core-3.0.0-IRIS.jar
+7204272b35891dca1d962af811dec92889d9564e5b200b5a50485101557e2f36  rskj-core/build/libs/rskj-core-3.0.0-IRIS.pom
 ```
 
 For SHA256 sum of older versions check the [releases page](https://github.com/rsksmart/rskj/releases).

--- a/kb/rskj-for-developers.md
+++ b/kb/rskj-for-developers.md
@@ -22,7 +22,7 @@ Running RSKj in Regtest mode is the best fit for these needs.
 
 - Navigate to [RSKj's releases page](https://github.com/rsksmart/rskj/releases)
 - From the **latest** release, download a file whose name looks like
-  `rskj-core-*.jar`, where `*` is replaced by the release tag name, for example `2.2.0-PAPYRUS`.
+  `rskj-core-*.jar`, where `*` is replaced by the release tag name, for example `3.0.0-IRIS`.
   
 ### Run RSKj
 

--- a/libraries/rsk-precompiled-abis/index.md
+++ b/libraries/rsk-precompiled-abis/index.md
@@ -67,3 +67,4 @@ If the version to be installed is not defined in the command line, the version w
 | 2.0.1-WASABI    | WASABI-1.0.0  |
 | 3.0.0-PAPYRUS   | PAPYRUS-2.0.0 |
 | 3.0.0-PAPYRUS   | PAPYRUS-2.2.0 |
+| 3.0.0-IRIS      | IRIS-3.0.0    |

--- a/rif/enveloping/requirements.md
+++ b/rif/enveloping/requirements.md
@@ -6,7 +6,7 @@ tags: rif, enveloping, rsk, envelope, gas station network, gsn, requirements
 
 ### RSK Node
 
-You need to have a running RSK node version [PAPYRUS-2.2.0](https://github.com/rsksmart/rskj/releases) or higher.
+You need to have a running RSK node version [IRIS-3.0.0](https://github.com/rsksmart/rskj/releases) or higher.
 
 ### Yarn
 


### PR DESCRIPTION
## What

- Updated RSKj from Papyrus 2.2.0 to IRIS 3.0.0

## Why

- Doc maintenance
- IRIS 3.0.0 released

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-160?atlOrigin=eyJpIjoiYzUxYmI3NWI3ODVlNGFiN2I1MDU1MWFiMTQ3MjM0YTMiLCJwIjoiaiJ9)
