### PR TITLE
Docs: Added View an Account in the Block Explorer in Quick Start Transactions Page

### DIFF
--- a/guides/quickstart/transactions.md
+++ b/guides/quickstart/transactions.md
@@ -25,6 +25,12 @@ Since it is open and transparent, there is nothing stopping multiple block explo
 
 ## View account in the block explorer
 
+This short video demonstrates how to view an account the RSK testnet explorer.
+
+<div class="video-container">
+  <iframe width="949" height="534" src="https://www.youtube.com/embed/p-q7NBmEqBo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 For the RSK Mainnet, we would go to [`explorer.rsk.co`](https://explorer.rsk.co/).
 However, since we are currently connected to the RSK Testnet, we go to [`explorer.testnet.rsk.co`](https://explorer.testnet.rsk.co/) instead.
 

--- a/guides/quickstart/transactions.md
+++ b/guides/quickstart/transactions.md
@@ -25,7 +25,7 @@ Since it is open and transparent, there is nothing stopping multiple block explo
 
 ## View account in the block explorer
 
-This short video demonstrates how to view an account the RSK testnet explorer.
+Watch this short video demonstrating how to view an account in the block explorer.
 
 <div class="video-container">
   <iframe width="949" height="534" src="https://www.youtube.com/embed/p-q7NBmEqBo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
## What

- Added view an account in the block explorer video to transactions page in the quick start guide

## Why

- Doc maintenance
- Quick start guide

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-166?atlOrigin=eyJpIjoiNjJlOTg5ZGJkZGYyNGVjZDg0MjViM2UwMWUxNTQ5N2YiLCJwIjoiaiJ9)
