### PR TITLE
Fix title consistency among rif multisig pages and duplicated rif template entry

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -517,11 +517,8 @@
             </ul>
           </li>
           <li>
-            <a href="/rif/templates/">Use a RIF Template</a>
-          </li>
-          <li>
             <span class="fa fa-chevron-right"></span>
-            <a href="/rif/multisig/">Savings and Vault</a>
+            <a href="/rif/multisig/">Multisig</a>
             <ul>
               <li><a href="/rif/multisig/">Overview</a></li>
               <li><a href="/rif/multisig/product">Product</a></li>

--- a/rif/multisig/gnosis-summary.md
+++ b/rif/multisig/gnosis-summary.md
@@ -1,6 +1,6 @@
 ---
 layout: rsk
-title: Gnosis Summary
+title: The RIF Multisig - Gnosis Summary
 description: Overview of the gnosis integration
 tags: rif, gnosis, multisig
 render_features: 'collapsible'

--- a/rif/multisig/index.md
+++ b/rif/multisig/index.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
-title: RIF Savings and Vault Solution
-description: Overview of the RIF Savings and Vault solution
+title: RIF Multisig - Savings and Vault Solution
+description: Overview of the RIF Multisig - Savings and Vault solution
 tags: rif, gnosis, multisig
 ---
 

--- a/rif/multisig/product.md
+++ b/rif/multisig/product.md
@@ -1,11 +1,11 @@
 ---
 layout: rsk
-title:  The Product
-description: Overview of the RIF Savings and Vault Solution
+title:  The RIF Multisig Product
+description: Overview of the RIF Multisig, Savings and Vault Solution
 tags: rif, gnosis, multisig
 ---
 
-The product for RIF Savings and Vault consists of porting and increasing the existing Gnosis SDK to allow RSK developers to operate multisig accounts in a safe and intuitive way, following the documentation and a sample application that will help with the correct implementation of the Gnosis solution.
+The product for RIF Multisig consists of porting and increasing the existing Gnosis SDK to allow RSK developers to operate multisig accounts in a safe and intuitive way, following the documentation and a sample application that will help with the correct implementation of the Gnosis solution.
 
 In short, it implies:
 
@@ -17,7 +17,7 @@ In short, it implies:
 
 ## Features
 
-The RIF Savings and Vault solution will allow RSK developers to use our SDKs, and with the help of the documentation to:
+The RIF Multisig solution will allow RSK developers to use our SDKs, and with the help of the documentation to:
 
 * Create multisig account, choosing its owners and threshold
 * CRUD multisig owners and threshold

--- a/rif/multisig/sample-application.md
+++ b/rif/multisig/sample-application.md
@@ -1,7 +1,7 @@
 ---
 layout: rsk
-title: RIF Savings and Vault Solution - Sample Application
-description: Sample application for the RIF Savings and Vault project showing the multisig SDKs usage.
+title: RIF Multisig - Savings and Vault Solution - Sample Application
+description: Sample application for the RIF Multisig - Savings and Vault project showing the multisig SDKs usage.
 tags: rif, gnosis, multisig, sdks, react
 ---
 

--- a/rif/multisig/transaction-service.md
+++ b/rif/multisig/transaction-service.md
@@ -1,6 +1,6 @@
 ---
 layout: rsk
-title: RIF Multisig Architecture - Safe Contracts
+title: RIF Multisig - Transaction Service
 description: API to keep track of transactions sent via Gnosis Safe smart contracts
 tags: rif, multisig, gnosis, service, backend
 ---


### PR DESCRIPTION
## What

- Changes RIF Multisig page title
- Removes the rif template entry duplicate from the menu.

## Why

- The RIF Multisig project was called sometimes "Savings and Vault Solution", while the marketing team is using the terms "RIF Multisig", so we dediced to keep consistency.
- The rif template entry was duplicated in the nav menu.
- The title of the transaction service page was wrong.

