### PR TITLE
Chore: Removed RSK Academy Web Links

### DIFF
--- a/rif/rlogin/integrations.md
+++ b/rif/rlogin/integrations.md
@@ -42,7 +42,6 @@ We are currently integrated with the following dApps
 
 - E) RSK Academy
   * RSK education platform. Find out brand new courses and live classes!
-  * URL: [academy.rsk.dev.br](https://academy.rsk.dev.br/)
   * Repo: [`rsksmart/rsk-academy`](https://github.com/rsksmart/rsk-academy)
 
 - F) rLending


### PR DESCRIPTION
## What

- Removed RSK Academy Web Links

## Why

- Potential issues raised by security

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-170?atlOrigin=eyJpIjoiNjg0NDIzMmIzYTA4NDZkZGE2NmQ3MzI5ODMyZDMyOTQiLCJwIjoiaiJ9)
