### PR TITLE
Chore: Added Link to Configure Truffle to RSK in Full Stack dApp Guide

### DIFF
--- a/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
+++ b/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
@@ -787,6 +787,8 @@ when you used the `npm install` command
 
 ### 5.3 Configure `truffle-config.js` file
 
+Read about how to [Configure Truffle to Connect to RSK](/kb/configure/truffle-to-rsk) using Truffle's default configuration values(based on Ethereum), and using 2 relatively new config options to configure Truffle to better connect to an RSK node.
+
 In the root folder directory, locate the `truffle-config.js` file.
 Truffle has already been pre-configured to connect to
 your choice of RSK Regtest or RSK Testnet.

--- a/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
+++ b/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
@@ -787,7 +787,7 @@ when you used the `npm install` command
 
 ### 5.3 Configure `truffle-config.js` file
 
-Read about how to [Configure Truffle to Connect to RSK](/kb/configure/truffle-to-rsk) using Truffle's default configuration values(based on Ethereum), and using 2 relatively new config options to configure Truffle to better connect to an RSK node.
+Read about how to [Configure Truffle to Connect to RSK](/kb/configure/truffle-to-rsk) using Truffle's default configuration values (based on Ethereum), and using 2 relatively new config options to configure Truffle to better connect to an RSK node.
 
 In the root folder directory, locate the `truffle-config.js` file.
 Truffle has already been pre-configured to connect to

--- a/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
+++ b/guides/full-stack-dapp-on-rsk/part2-smart-contracts.md
@@ -787,7 +787,7 @@ when you used the `npm install` command
 
 ### 5.3 Configure `truffle-config.js` file
 
-Read about how to [Configure Truffle to Connect to RSK](/kb/configure/truffle-to-rsk) using Truffle's default configuration values (based on Ethereum), and using 2 relatively new config options to configure Truffle to better connect to an RSK node.
+Read about how to [Configure Truffle to Connect to RSK](/kb/configure-truffle-to-rsk) using Truffle's default configuration values (based on Ethereum), and using 2 relatively new config options to configure Truffle to better connect to an RSK node.
 
 In the root folder directory, locate the `truffle-config.js` file.
 Truffle has already been pre-configured to connect to


### PR DESCRIPTION
## What

- Added a link to configure Truffle to RSK in Full Stack dApp Guide

## Why

- Guides on RSK
- Developer Documentation

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-176?atlOrigin=eyJpIjoiMzdhOTk2ZDlmMTllNDRlZWIyNWUwMGE4Yzk3OTQ5YzAiLCJwIjoiaiJ9)
