### PR TITLE
Chore: Updated node version to IRIS-3.1.0 in Tutorials and Guides

### DIFF
--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -98,26 +98,26 @@ it is always good practice to verify that your copy is legitimate.
 Let's compute the checksum using the following command:
 
 ```shell
-sha256sum rskj-core-2.0.1-PAPYRUS-all.jar
+sha256sum rskj-core-3.1.0-IRIS-all.jar
 ```
 
 For this version, the output should look like this:
 
 ```shell
-43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0 *rskj-core-2.0.1-PAPYRUS-all.jar
+43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0 *rskj-core-3.1.0-IRIS-all.jar
 ```
 
 On Windows, use this command instead:
 
 ```windows-command-prompt
-C:\>certutil -hashfile rskj-core-2.0.1-PAPYRUS-all.jar SHA256
+C:\>certutil -hashfile rskj-core-3.1.0-IRIS-all.jar SHA256
 
 ```
 
 For this version, the output on windows should look like this:
 
 ```windows-command-prompt
-SHA256 hash of rskj-core-2.0.1-PAPYRUS-all.jar:
+SHA256 hash of rskj-core-3.1.0-IRIS-all.jar:
 43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0
 CertUtil: -hashfile command completed successfully.
 
@@ -144,7 +144,7 @@ java -classpath <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.provider
 > Example:
 >
 > ```windows-command-prompt
-> C:\>java -classpath C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
+> C:\>java -classpath C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
 >
 > ```
 

--- a/tutorials/ethereum-devs/geth-attach-local-node.md
+++ b/tutorials/ethereum-devs/geth-attach-local-node.md
@@ -90,14 +90,14 @@ mkdir rskj-node
 cd rskj-node
 curl \
   -L \
-  https://github.com/rsksmart/rskj/releases/download/PAPYRUS-2.0.1/rskj-core-2.0.1-PAPYRUS-all.jar \
-  > ./rskj-core-2.0.1-PAPYRUS-all.jar
+  https://github.com/rsksmart/rskj/releases/download/IRIS-3.1.0/rskj-core-3.1.0-IRIS-all.jar \
+  > ./rskj-core-3.1.0-IRIS-all.jar
 curl \
   -L \
-  https://github.com/rsksmart/rskj/releases/download/PAPYRUS-2.0.1/SHA256SUMS.asc \
-  > ./rskj-core-2.0.1-PAPYRUS-all.SHA256SUMS.asc
-shasum rskj-core-2.0.1-PAPYRUS-all.jar
-grep "rskj-core" rskj-core-2.0.1-PAPYRUS-all.SHA256SUMS.asc
+  https://github.com/rsksmart/rskj/releases/download/IRIS-3.1.0/SHA256SUMS.asc \
+  > ./rskj-core-3.1.0-IRIS-all.SHA256SUMS.asc
+shasum rskj-core-3.1.0-IRIS-all.jar
+grep "rskj-core" rskj-core-3.1.0-IRIS-all.SHA256SUMS.asc
 ```
 
 The curl commands download a binary which is the RSKj executable, as well as a plain text file containing the checksum for the JAR file. The subsequent `shasum` (or `sha256sum` depending on your *NIX variety), and `grep` are used to verify that the checksum recorded as part of the release process does indeed match the computed checksum of the file that was downloaded.
@@ -118,20 +118,20 @@ java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --regtest
 
 
 I am using a Windows OS and I saved the file at `C:\RSK\node`,
-so for me the full path is `C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar`.
+so for me the full path is `C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar`.
 
 The commands required to run the RSK node are:
 
 #### On Windows
 
 ```shell
-java -cp C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar co.rsk.Start --regtest
+java -cp C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar co.rsk.Start --regtest
 ```
 
 #### On Linux and Mac
 
 ```shell
-java -cp C:/RSK/node/rskj-core-2.0.1-PAPYRUS-all.jar co.rsk.Start --regtest
+java -cp C:/RSK/node/rskj-core-3.1.0-IRIS-all.jar co.rsk.Start --regtest
 ```
 
 If you do not have any output after running the command, this usually means that the node is running successfully. We will confirm this in the next step.

--- a/tutorials/ethereum-devs/setup-truffle-oz.md
+++ b/tutorials/ethereum-devs/setup-truffle-oz.md
@@ -206,13 +206,13 @@ it is always a good idea to verify that your copy is legitimate.
 In the folder where you download the JAR file, go to a POSIX terminal and run this command:
 
 ```shell
-sha256sum rskj-core-2.0.1-PAPYRUS-all.jar
+sha256sum rskj-core-3.1.0-IRIS-all.jar
 ```
 
 For this version, it looked like this:
 
 ```shell
-43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0 *rskj-core-2.0.1-PAPYRUS-all.jar
+43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0 *rskj-core-3.1.0-IRIS-all.jar
 ```
 
 ![Verify authenticity](/assets/img/tutorials/setup-truffle-oz/image-08.png)
@@ -236,26 +236,26 @@ java -cp <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regtes
 (Replace <PATH-TO-THE-RSKJ-JAR> with your path to the JAR file).
 
 I am using a Windows OS and I saved the file at `C:\RSK\node`,
-so for me the full path is `C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar`.
+so for me the full path is `C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar`.
 
 The commands required to run the RSK node are:
 
 #### On Windows terminal
 
 ```shell
-java -cp C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
 ```
 
 #### Using Git Bash
 
 ```shell
-java -cp C:/RSK/node/rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp C:/RSK/node/rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
 ```
 
 #### On Linux and Mac
 
 ```shell
-java -cp ~/RSK/node/rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp ~/RSK/node/rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
 ```
 
 If you see no output - that is a good thing:

--- a/tutorials/ethereum-devs/truffle-test.md
+++ b/tutorials/ethereum-devs/truffle-test.md
@@ -65,11 +65,11 @@ Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example:
 [](#top "multiple-terminals")
 - Linux, Mac OSX
   ```shell
-  $ java -cp C:/RskjCode/rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+  $ java -cp C:/RskjCode/rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
   ```
 - Windows
   ```windows-command-prompt
-  C:\> java -cp C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+  C:\> java -cp C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
   ```
 
 If you see no output - that is a good thing:

--- a/tutorials/frontend/frontend-web3-local.md
+++ b/tutorials/frontend/frontend-web3-local.md
@@ -149,20 +149,20 @@ java -cp <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* co.rsk.Start --regtes
 
 (Replace <PATH-TO-THE-RSKJ-JAR> with your path to the JAR file). 
 
-I am using a Windows OS and I saved the file at `C:\RSK\node`, so for me the full path is `C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar`
+I am using a Windows OS and I saved the file at `C:\RSK\node`, so for me the full path is `C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar`
 
 The commands required to run the RSK node are:
 
 ### On Windows
 
 ```shell
-java -cp C:\RSK\node\rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
 ```
 
 ### On Linux and Mac
 
 ```shell
-java -cp /RSK/node/rskj-core-2.0.1-PAPYRUS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp /RSK/node/rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* co.rsk.Start --regtest
 ```
 
 Check the tutorial: [using Geth attach to a RSK local node](/tutorials/ethereum-devs/geth-attach-local-node/) for more details on how to do this.

--- a/tutorials/truffle-boxes/pet-shop-box.md
+++ b/tutorials/truffle-boxes/pet-shop-box.md
@@ -299,10 +299,10 @@ mkdir -p ~/code/rsk/rskj-node
 cd ~/code/rsk/rskj-node
 curl \
   -L \
-  https://github.com/rsksmart/rskj/releases/download/PAPYRUS-2.0.1/rskj-core-2.0.1-PAPYRUS-all.jar \
-  > ./rskj-core-2.0.1-PAPYRUS-all.jar
-sha256sum rskj-core-2.0.1-PAPYRUS-all.jar
-# 43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0  rskj-core-2.0.1-PAPYRUS-all.jar
+  https://github.com/rsksmart/rskj/releases/download/IRIS-3.1.0/rskj-core-3.1.0-IRIS-all.jar \
+  > ./rskj-core-3.1.0-IRIS-all.jar
+sha256sum rskj-core-3.1.0-IRIS-all.jar
+# 43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0  rskj-core-3.1.0-IRIS-all.jar
 
 ```
 
@@ -315,7 +315,7 @@ For the purposes of this workshop,
 we will run RSKj on Regtest.
 
 ```shell
-java -cp rskj-core-2.0.1-PAPYRUS-all.jar co.rsk.Start --regtest
+java -cp rskj-core-3.1.0-IRIS-all.jar co.rsk.Start --regtest
 
 ```
 


### PR DESCRIPTION
## What

- Updated node version in tutorials and guides to IRIS-3.1.0

## Why

- New node version has just been released

## Refs

- [Task](https://rsklabs.atlassian.net/browse/EC-185?atlOrigin=eyJpIjoiYTdkYjM1OGY1OWUzNDAzYzllNTIwNGE1N2I2ZmFiZWEiLCJwIjoiaiJ9)
