### PR TITLE
Chore: renamed url for hardhat tutorial

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -620,7 +620,7 @@
           <li><a href="/kb/ethereum-dapp-to-rsk/">Bring your Ethereum dApp to RSK</a></li>
           <li><a href="/kb/getblock-rpc/">RPC via GetBlock</a></li>
           <li><a href="/kb/verify-smart-contract/">Verify Smart Contracts</a></li>
-          <li><a href="/kb/hardhat-project-on-rsk/">Set up Hardhat project for RSK Testnet</a></li>
+          <li><a href="/kb/hardhat-setup-on-rsk/">Set up Hardhat project for RSK Testnet</a></li>
         </ul>
       </li> <!-- /KB -->
       <li class="first_level">

--- a/kb/hardhat-setup-on-rsk.md
+++ b/kb/hardhat-setup-on-rsk.md
@@ -140,7 +140,7 @@ module.exports = {
 };
 ```
 
-To set such networks, you’ll have to configure the object with following fields : 
+To set such networks, you’ll have to configure the object with the following fields: 
 
 - `url`: This is the url of the node for custom networks.
 - `chainId`: This number is used to validate the network Hardhat connects to.
@@ -148,7 +148,7 @@ To set such networks, you’ll have to configure the object with following field
 - `gasMultiplier`: Default value : 1
 - `accounts`: This field controls the account that Hardhat uses. It can use node’s accounts or an HD Wallet. Default : “remote”.
 
-### 2.5. HD Wallet Configuration : 
+### 2.5. HD Wallet Configuration
 
 For using HD Wallet with Hardhat, you’ll have to set your network’s account with the below fields.
 

--- a/kb/index.md
+++ b/kb/index.md
@@ -477,7 +477,7 @@ description: "Welcome to RSK and RIF Knowledge-base; Explore our faqs, tutorials
     </li>
      <li class="col-xl-6 col-md-6">
         <div class="feature-card">
-            <a href="/kb/hardhat-project-on-rsk/">
+            <a href="/kb/hardhat-setup-on-rsk/">
                 <div class="icon rif h-100">
                     <div class="icon-cont text-center my-auto">
                         <img src="/assets/img/rsk_logo.svg" alt="rsk icon">
@@ -485,7 +485,7 @@ description: "Welcome to RSK and RIF Knowledge-base; Explore our faqs, tutorials
                 </div>
             </a>
             <div class="content">
-                <a href="/kb/hardhat-project-on-rsk/">
+                <a href="/kb/hardhat-setup-on-rsk/">
                     <div class="content-container">
                         <p class="card-title rsk_green">How to set up a Hardhat project for RSK Testnet</p>
                         <p class="card-desc">Learn how to set up a Hardhat project for RSK Testnet.
@@ -494,7 +494,7 @@ description: "Welcome to RSK and RIF Knowledge-base; Explore our faqs, tutorials
                 </a>
                 <div class="btn-container">
                     <span></span>
-                    <a class="green" href="/kb/hardhat-project-on-rsk/">Read More</a>
+                    <a class="green" href="/kb/hardhat-setup-on-rsk/">Read More</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## What

- Changed URL from hardhat-project-on-rsk to hardhat-setup-on-rsk

## Why

- SEO purposes

## Refs

- [Task](https://www.notion.so/iovlabs/Proofread-Hardhat-tutorial-43e84ce56841487cb145828db1c66315)
