### PR TITLE
feat: google search

### DIFF
--- a/_includes/nav-page-menu.html
+++ b/_includes/nav-page-menu.html
@@ -1,7 +1,5 @@
 <div class="menu-container">
-  {% comment %}
   {% include search.html %}
-  {% endcomment %}
   <br/>
   <div class="container p-0">
     <div>

--- a/search/index.html
+++ b/search/index.html
@@ -1,6 +1,6 @@
 ---
 layout: rsk
-title: "Search Result"
+title: "Search Results"
 skip_search: true
 ---
 
@@ -11,4 +11,7 @@ skip_search: true
 </div>
 
 <!-- Script pointing to search-script.js -->
-<script src="search.js" type="text/javascript"></script>
+<!-- <script src="search.js" type="text/javascript"></script> -->
+
+<div class="gcse-searchresults-only"></div>
+<script async src="https://cse.google.com/cse.js?cx=975d142d5714308b8"></script>


### PR DESCRIPTION
## What

- add google programmable search engine to the search results page

## Why

- previous search result quality was poor

## Refs

- [feat: disable search in nav menu #783](https://github.com/rsksmart/devportal/pull/783)

## Comments

[Google Programmable Search Engine](https://programmablesearchengine.google.com/) needs to be registered at a Google account. For now I registered and configured it at my personal account ales.very@gmail.com . Search is restricted to developers.rsk.co . Now it uses a free tariff plan, which means, it shows some advertisement. [Adds-free API](https://developers.google.com/custom-search/docs/paid_element) charges $5 per 1000  search queries.
