### PR TITLE
fix: GitHub links verifier

### DIFF
--- a/.scripts/md-github-links-verifier.js
+++ b/.scripts/md-github-links-verifier.js
@@ -21,7 +21,7 @@ function getAllMdFiles(dirPath = '../', arrayOfFiles = []) {
     ) {
       files = getAllMdFiles(`${dirPath}/${file}`, files);
     } else if (extname(file) === '.md') {
-      files.push(join(dirPath, '/', file));
+      files.push(join(__dirname, '../', dirPath, '/', file));
     }
   });
   return files;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "generate-webinar-ical": "node .scripts/generate-webinar-ical.js",
     "generate-webinar-json": "node .scripts/generate-webinar-json.js",
     "generate-webinar-dedupe": "node .scripts/generate-webinar-dedupe.js",
-    "generate-webinar-pages": "node .scripts/generate-webinar-pages.js"
+    "generate-webinar-pages": "node .scripts/generate-webinar-pages.js",
+    "verify-github-links": "node .scripts/md-github-links-verifier.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

- add github links verifier script to package.json. Run "npm run verify-github-links" to start links verifier
- modify file urls in broken-links.json to begin with the project root url instead of the relative '../'

## Why

- changes requested by Brendan in a kanban ticket

## Refs

- [Notion Kanban ticket](https://www.notion.so/iovlabs/9f73ce020c4941e7a3f837fb4ac7a746?v=c421d3ea5aed4f5ebe99a919cac93510&p=6221cc61dd8147bcbb80c9c0da2116be)
