### PR TITLE
2wp minimum update

### DIFF
--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -88,7 +88,7 @@ RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
   <strong>at least 0.004 RBTC</strong>
   for Mainnet
   Sending any lower amount fails and
-  <strong>funds will be lost</strong>.
+  <strong>funds will be reimbursed</strong>.
   The Gas Limit of the transaction needs to be manually set at 100,000 gas;
   otherwise the transaction will fail.
   Gas Price can be set to 0.06 gwei

--- a/_rsk/rbtc/conversion/networks/mainnet.md
+++ b/_rsk/rbtc/conversion/networks/mainnet.md
@@ -9,7 +9,7 @@ permalink: /rsk/rbtc/conversion/networks/mainnet/
 
 In this section we will go over the steps of converting BTC to RBTC and vice versa in Bitcoin and RSK Mainnets.
 
-> Note: The minimum amount of Bitcoin to convert is **0.01 BTC** for Mainnet.
+> Note: The minimum amount of Bitcoin to convert is **0.005 BTC** for Mainnet.
 
 ## BTC to RBTC conversion
 

--- a/_rsk/rbtc/conversion/networks/testnet.md
+++ b/_rsk/rbtc/conversion/networks/testnet.md
@@ -11,7 +11,7 @@ In this section we will go over the steps of converting t-BTC to tRBTC,
 and vice versa on the Bitcoin and RSK Testnets.
 
 Note:
-The minimum amount of Bitcoin to convert is **0.01 tBTC** for Testnet.
+The minimum amount of Bitcoin to convert is **0.005 tBTC** for Testnet.
 
 ## tBTC to tRBTC conversion
 

--- a/_rsk/rbtc/conversion/networks/testnet.md
+++ b/_rsk/rbtc/conversion/networks/testnet.md
@@ -88,7 +88,7 @@ You can get a corresponding tBTC address from your tRBTC private key by using [g
 
 RSK Bridge Contract address: `0x0000000000000000000000000000000001000006`
 
-> **Important note**: The minimum amount to send must be **greater than** 0.005 tRBTC for Testnet (sending the exact amount fails and funds get lost)
+> **Important note**: The minimum amount to send must be **at least** 0.004 tRBTC for Testnet, values below that will be rejected and reimbursed to the sender.
 
 Gas Limit of the transaction needs to be manually set at 100,000 gas;
 otherwise the transaction will fail.


### PR DESCRIPTION
## What

Changed the minimum values for peg-in and peg-out on Mainnet and Testnet

## Why

- The consensus rules for these minimum values changes on Iris and we didn't update the dev portal accordingly
