### PR TITLE
change minimum requirement to run an RSK node

### DIFF
--- a/_rsk/node/install/requirements.md
+++ b/_rsk/node/install/requirements.md
@@ -10,5 +10,5 @@ These are the minimum requirements that must be met to run an RSK node:
 
 - 2 cores
 - 8 GB RAM
-- 50 GB storage
+- 128 GB storage
 - OS x64


### PR DESCRIPTION
## What

- change the minimum requirement for storage from 50 to 128 GB to run an RSK node

## Why

- update dev portal 

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
