### PR TITLE
Add documentation about RocksDB usage

### DIFF
--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -46,11 +46,13 @@ This is known as the *Blockchain Database*.
   Indicates that the block database should be erased, and should start from scratch,
   i.e. from genesis block.
   This is typically expected to be used when connecting to RSK Regtest,
-  or in select debugging scenarios.
+  or in select debugging scenarios. It is also used when switching between different databases,
+  i.e. from `leveldb` to `rocksdb`.
 - `--import`:
   Indicates that the block database should be imported from an external source.
   This is typically expected to be used when connecting to RSK Testnet or RSK Mainnet,
-  and when a reduction in "initial sync time" is desired.
+  and when a reduction in "initial sync time" is desired. It is also used when switching between different databases,
+  i.e. from `leveldb` to `rocksdb`.
 
 ### Configuration related
 

--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -52,8 +52,9 @@ This is known as the *Blockchain Database*.
 - `--import`:
   Indicates that the block database should be imported from an external source.
   This is typically expected to be used when connecting to RSK Testnet or RSK Mainnet,
-  and when a reduction in "initial sync time" is desired. It is also used when switching between different databases,
-  i.e. from `leveldb` to `rocksdb`.
+  and when a reduction in "initial sync time" is desired.
+  It is also used when switching between different databases,
+  e.g. between `leveldb` and `rocksdb`.
 
 ### Configuration related
 

--- a/_rsk/node/configure/cli.md
+++ b/_rsk/node/configure/cli.md
@@ -46,8 +46,9 @@ This is known as the *Blockchain Database*.
   Indicates that the block database should be erased, and should start from scratch,
   i.e. from genesis block.
   This is typically expected to be used when connecting to RSK Regtest,
-  or in select debugging scenarios. It is also used when switching between different databases,
-  i.e. from `leveldb` to `rocksdb`.
+  or in select debugging scenarios.
+  It is also used when switching between different databases,
+  e.g. between `leveldb` and `rocksdb`.
 - `--import`:
   Indicates that the block database should be imported from an external source.
   This is typically expected to be used when connecting to RSK Testnet or RSK Mainnet,

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -79,7 +79,7 @@ RocksDB is an embeddable persistent key-value store for fast storage.
 
 [GET STARTED](http://rocksdb.org/docs/getting-started.html).
 
-Adventages (taken from source):
+Advantages (taken from source):
 * RocksDB uses a log structured database engine, written entirely in C++, for maximum performance. Keys and values are just arbitrarily-sized byte streams.
 * RocksDB is optimized for fast, low latency storage such as flash drives and high-speed disk drives. RocksDB exploits the full potential of high read/write rates offered by flash or RAM.
 * RocksDB is adaptable to different workloads. From database storage engines such as [MyRocks](https://github.com/facebook/mysql-5.6) to [application data caching](http://techblog.netflix.com/2016/05/application-data-caching-using-ssds.html) to embedded workloads, RocksDB can be used for a variety of data needs.

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -68,7 +68,11 @@ This can be done in two ways:
 
 ### Using RocksDb (Experimental)
 
-Our current application runs using [LevelDB](https://dbdb.io/db/leveldb) and now we are introudcing a second storage option, [RocksDB](http://rocksdb.org/).
+By default, RSKj runs using [LevelDB](https://dbdb.io/db/leveldb).
+There is an option to use an alternate storage option,
+[RocksDB](http://rocksdb.org/), instead.
+The RocksDb option was introduced to enable higher performance
+within the RSKj nodes.
 
 [RocksDB](http://rocksdb.org/) is a persistent key-value store for fast storage environments
 RocksDB is an embeddable persistent key-value store for fast storage.

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -89,7 +89,8 @@ Adventages (taken from source):
 Modify the relevant RSKj config file (`*.conf`) file
 and set the property `keyvalue.datasource=rocksdb`.
 
-`keyvalue.datasource` supports either: `rocksdb` or `leveldb`
+The `keyvalue.datasource` property in the config
+may only be either `rocksdb` or `leveldb`.
 
 It is good idea to reset the database everytime you want to switch between different db storage, for instance from `leveldb` to `rocksdb` or viceversa, so that way the data is stored in the format of the selected DB.
 

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -84,8 +84,10 @@ Adventages (taken from source):
 * RocksDB is optimized for fast, low latency storage such as flash drives and high-speed disk drives. RocksDB exploits the full potential of high read/write rates offered by flash or RAM.
 * RocksDB is adaptable to different workloads. From database storage engines such as [MyRocks](https://github.com/facebook/mysql-5.6) to [application data caching](http://techblog.netflix.com/2016/05/application-data-caching-using-ssds.html) to embedded workloads, RocksDB can be used for a variety of data needs.
 * RocksDB provides basic operations such as opening and closing a database, reading and writing to more advanced operations such as merging and compaction filters.
+### How to use RocksDb
 
-In order to take advange if it's high performance, we added this experimental feature to our app. It could be used in the `*.conf` file by just setting `keyvalue.datasource=rocksdb`.
+Modify the relevant RSKj config file (`*.conf`) file
+and set the property `keyvalue.datasource=rocksdb`.
 
 `keyvalue.datasource` supports either: `rocksdb` or `leveldb`
 

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -66,7 +66,7 @@ This can be done in two ways:
 - Running the node with the `java` command, add `-Drsk.conf.file=path/to/your/file.conf`
 - Compiling the node with IntelliJ, add to VM options: `-Drsk.conf.file=path/to/your/file.conf`
 
-### Using RocksDb (Experimental)
+### Using RocksDB (Experimental)
 
 By default, RSKj runs using [LevelDB](https://dbdb.io/db/leveldb).
 There is an option to use an alternate storage option,

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -71,7 +71,7 @@ This can be done in two ways:
 By default, RSKj runs using [LevelDB](https://dbdb.io/db/leveldb).
 There is an option to use an alternate storage option,
 [RocksDB](http://rocksdb.org/), instead.
-The RocksDb option was introduced to enable higher performance
+The RocksDB option was introduced to enable higher performance
 within the RSKj nodes.
 
 [RocksDB](http://rocksdb.org/) is a persistent key-value store for fast storage environments

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -103,7 +103,7 @@ Note the use of the `--import` flag, which resets and re-imports the database.
 
 * `java -Dkeyvalue.datasource=rocksdb -jar ./rskj-core/build/libs/rskj-core-*-all.jar --testnet --import`
 
-**Warning:** be aware that this is a experimental version and it is still in test.
+**Warning:** This feature is considered experimental, do not use in production.
 
 ### Troubleshooting
 

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -84,7 +84,7 @@ Advantages (taken from source):
 * RocksDB is optimized for fast, low latency storage such as flash drives and high-speed disk drives. RocksDB exploits the full potential of high read/write rates offered by flash or RAM.
 * RocksDB is adaptable to different workloads. From database storage engines such as [MyRocks](https://github.com/facebook/mysql-5.6) to [application data caching](http://techblog.netflix.com/2016/05/application-data-caching-using-ssds.html) to embedded workloads, RocksDB can be used for a variety of data needs.
 * RocksDB provides basic operations such as opening and closing a database, reading and writing to more advanced operations such as merging and compaction filters.
-### How to use RocksDb
+### How to use RocksDB
 
 Modify the relevant RSKj config file (`*.conf`) file
 and set the property `keyvalue.datasource=rocksdb`.

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -66,6 +66,33 @@ This can be done in two ways:
 - Running the node with the `java` command, add `-Drsk.conf.file=path/to/your/file.conf`
 - Compiling the node with IntelliJ, add to VM options: `-Drsk.conf.file=path/to/your/file.conf`
 
+### Using RocksDb (Experimental)
+
+Our current application runs using [LevelDB](https://dbdb.io/db/leveldb) and now we are introudcing a second storage option, [RocksDB](http://rocksdb.org/).
+
+[RocksDB](http://rocksdb.org/) is a persistent key-value store for fast storage environments
+RocksDB is an embeddable persistent key-value store for fast storage.
+
+[GET STARTED](http://rocksdb.org/docs/getting-started.html).
+
+Adventages (taken from source):
+* RocksDB uses a log structured database engine, written entirely in C++, for maximum performance. Keys and values are just arbitrarily-sized byte streams.
+* RocksDB is optimized for fast, low latency storage such as flash drives and high-speed disk drives. RocksDB exploits the full potential of high read/write rates offered by flash or RAM.
+* RocksDB is adaptable to different workloads. From database storage engines such as [MyRocks](https://github.com/facebook/mysql-5.6) to [application data caching](http://techblog.netflix.com/2016/05/application-data-caching-using-ssds.html) to embedded workloads, RocksDB can be used for a variety of data needs.
+* RocksDB provides basic operations such as opening and closing a database, reading and writing to more advanced operations such as merging and compaction filters.
+
+In order to take advange if it's high performance, we added this experimental feature to our app. It could be used in the `*.conf` file by just setting `keyvalue.datasource=rocksdb`.
+
+`keyvalue.datasource` supports either: `rocksdb` or `leveldb`
+
+It is good idea to reset the database everytime you want to switch between different db storage, for instance from `leveldb` to `rocksdb` or viceversa, so that way the data is stored in the format of the selected DB.
+
+Sample command using `rocksdb` when the previous db was `leveldb` (notice we add `--import` at the end to reset and re-import the database):
+
+* `java -Dkeyvalue.datasource=rocksdb -jar ./rskj-core/build/libs/rskj-core-*-all.jar --testnet --import`
+
+**Warning:** be aware that this is a experimental version and it is still in test.
+
 ### Troubleshooting
 
 #### UDP port already in use

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -92,9 +92,14 @@ and set the property `keyvalue.datasource=rocksdb`.
 The `keyvalue.datasource` property in the config
 may only be either `rocksdb` or `leveldb`.
 
-It is good idea to reset the database everytime you want to switch between different db storage, for instance from `leveldb` to `rocksdb` or viceversa, so that way the data is stored in the format of the selected DB.
+If you wish to switch between the different storage options,
+for example from `leveldb` to `rocksdb` or vice versa, 
+you must **restart** the node with the import option.
 
-Sample command using `rocksdb` when the previous db was `leveldb` (notice we add `--import` at the end to reset and re-import the database):
+The following sample command show how to do this when
+the RSKj node was previously running the default (`leveldb`),
+and wants to run with `rocksdb` next.
+Note the use of the `--import` flag, which resets and re-imports the database.
 
 * `java -Dkeyvalue.datasource=rocksdb -jar ./rskj-core/build/libs/rskj-core-*-all.jar --testnet --import`
 

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -96,7 +96,7 @@ If you wish to switch between the different storage options,
 for example from `leveldb` to `rocksdb` or vice versa, 
 you must **restart** the node with the import option.
 
-The following sample command show how to do this when
+The following sample command shows how to do this when
 the RSKj node was previously running the default (`leveldb`),
 and wants to run with `rocksdb` next.
 Note the use of the `--import` flag, which resets and re-imports the database.

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -121,6 +121,17 @@ Options related to experimental import sync v0.1.
 * `database.import.enabled = [true/false]`
   enable the import sync.
 
+## keyvalue.datasource (experimental)
+
+Selects the database that will be used to store the information. Possible databases are to select are:
+
+* `leveldb` (default).
+* `rocksdb` (experimental)
+
+It is good idea to reset the database everytime you want to switch between different db storage, for instance from `leveldb` to `rocksdb` or viceversa, so that way the data is stored in the format of the selected DB.
+
+**Warning:** be aware that this is a experimental version and it is still in test.
+
 ## vm
 
 Enabling the `vm.structured` will log all the calls to the VM in the local database.

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -129,7 +129,9 @@ Possible options are:
 * `leveldb` (default)
 * `rocksdb` (experimental)
 
-It is good idea to reset the database everytime you want to switch between different db storage, for instance from `leveldb` to `rocksdb` or viceversa, so that way the data is stored in the format of the selected DB.
+If you wish to switch between the different storage options,
+for example from `leveldb` to `rocksdb` or vice versa, 
+you must **restart** the node with the import option each time you do so.
 
 **Warning:** be aware that this is a experimental version and it is still in test.
 

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -133,7 +133,7 @@ If you wish to switch between the different storage options,
 for example from `leveldb` to `rocksdb` or vice versa, 
 you must **restart** the node with the import option each time you do so.
 
-**Warning:** be aware that this is a experimental version and it is still in test.
+**Warning:** This feature is considered experimental, do not use in production.
 
 ## vm
 

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -123,9 +123,10 @@ Options related to experimental import sync v0.1.
 
 ## keyvalue.datasource (experimental)
 
-Selects the database that will be used to store the information. Possible databases are to select are:
+Selects the database that will be used to store the information.
+Possible options are:
 
-* `leveldb` (default).
+* `leveldb` (default)
 * `rocksdb` (experimental)
 
 It is good idea to reset the database everytime you want to switch between different db storage, for instance from `leveldb` to `rocksdb` or viceversa, so that way the data is stored in the format of the selected DB.


### PR DESCRIPTION
## What

- We are adding a new DB option (RocksDB) that works faster than current one (LevelDB).
- We are documenting how to setup the application so we can select which db to use.

## Why

- There are small configurations that are needed in order to use this experimental feature
- There are some warnings to consider like for example we should reset database whenever we change from database to another type of database because data is not stored in the same format or at least a compatible format.

## Refs

- https://github.com/rsksmart/rskj/pull/1703
