### PR TITLE
add deprecation statement to libraries page

### DIFF
--- a/libraries/index.md
+++ b/libraries/index.md
@@ -4,9 +4,9 @@ title: Libs
 tags: libraries, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
-Attention
+**Attention**
 
-We are aware that you maybe having challenges when using the rsk3.js library. This is to inform you that the **rsk3.js** library has been deprecated and is no longer supported. Please use [web3.js](https://web3js.readthedocs.io/)  or [ethers.js](https://docs.ethers.io/v5/) instead. All references to rsk3.js library has been removed.
+We are aware that you maybe having challenges when using the rsk3.js library. This is to inform you that the **rsk3.js** library has been deprecated and is no longer supported. Please use [web3.js](https://web3js.readthedocs.io/)  or [ethers.js](https://docs.ethers.io/v5/) instead. Also note that all references to `rsk3.js` library has been removed from the RSK Developers Portal.
 
 Apologies for any inconvenience this may have caused. Also reach out to us on [Open Slack](https://developers.rsk.co/slack/) if you have any questions.
 

--- a/libraries/index.md
+++ b/libraries/index.md
@@ -4,6 +4,12 @@ title: Libs
 tags: libraries, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
+Attention
+
+We are aware that you maybe having challenges when using the rsk3.js library. This is to inform you that the **rsk3.js** library has been deprecated and is no longer supported. Please use [web3.js](https://web3js.readthedocs.io/)  or [ethers.js](https://docs.ethers.io/v5/) instead. All references to rsk3.js library has been removed.
+
+Apologies for any inconvenience this may have caused. Also reach out to us on [Open Slack](https://developers.rsk.co/slack/) if you have any questions.
+
 ## RSK Libraries
 
 - [RSK Pre-compiled ABIs](/libraries/rsk-precompiled-abis/)


### PR DESCRIPTION
## What

- add a deprecation statement to the libraries page

## Why

- Because rsk3.js has been deprecated and is no longer supported.

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
