### PR TITLE
Add docs in regards to database migration tool

### DIFF
--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -110,6 +110,8 @@ This tool allows the user to migrate between different supported databases such 
 
 #### How to use
 
+To use the `DbMigrate` tool to migrate between databases, we will need a tool class and CLI arguments.
+
 The tool class is: `co.rsk.cli.tools.DbMigrate`
 
 Required cli args:

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -119,7 +119,6 @@ Required CLI arguments:
 `args[0]` - database target where we are going to insert the information from the current selected database.
 Be aware that you cannot migrate to the same database or an error will be thrown.
 
-It is highly recommended to turn off the node in order to perform the migration since latest data could be lost.
 
 Example migrating from `leveldb` to `rocksdb`:
 

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -108,7 +108,7 @@ The above command removes the blocks with number 1000001 or higher.
 
 This tool allows the user to migrate between different supported databases such as `rocksdb` and `leveldb`. 
 
-#### How to use it
+#### How to use
 
 The tool class is: `co.rsk.cli.tools.DbMigrate`
 

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -114,7 +114,7 @@ To use the `DbMigrate` tool to migrate between databases, we will need a tool cl
 
 The tool class is: `co.rsk.cli.tools.DbMigrate`
 
-Required cli args:
+Required CLI arguments:
 
 `args[0]` - database target where we are going to insert the information from the current selected database.
 Be aware that you cannot migrate to the same database or an error will be thrown.

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -117,7 +117,7 @@ The tool class is: `co.rsk.cli.tools.DbMigrate`
 Required CLI arguments:
 
 `args[0]` - database target where we are going to insert the information from the current selected database.
-Be aware that you cannot migrate to the same database or an error will be thrown.
+> Note: You cannot migrate to the same database or an error will be thrown. It is highly recommended to turn off the node in order to perform the migration since latest data could be lost.
 
 
 Example migrating from `leveldb` to `rocksdb`:

--- a/_rsk/node/troubleshooting.md
+++ b/_rsk/node/troubleshooting.md
@@ -103,3 +103,22 @@ Example:
 `java -cp rsk-core-<VERSION>.jar co.rsk.cli.tools.RewindBlocks 1000000`
 
 The above command removes the blocks with number 1000001 or higher.
+
+### DbMigrate: Migrate between databases
+
+This tool allows the user to migrate between different supported databases such as `rocksdb` and `leveldb`. 
+
+#### How to use it
+
+The tool class is: `co.rsk.cli.tools.DbMigrate`
+
+Required cli args:
+
+`args[0]` - database target where we are going to insert the information from the current selected database.
+Be aware that you cannot migrate to the same database or an error will be thrown.
+
+It is highly recommended to turn off the node in order to perform the migration since latest data could be lost.
+
+Example migrating from `leveldb` to `rocksdb`:
+
+`java -cp rsk-core-<VERSION>.jar co.rsk.cli.tools.DbMigrate rocksdb`


### PR DESCRIPTION
## What

- Created a tool that allows the user to migrate between databases: `rocksdb` and `leveldb`

## Why

- We wanted to give our users an alternative to use our databases without the need of resetting the database and sync the node again.

## Refs

- https://github.com/rsksmart/rskj/pull/1834
