### PR TITLE
Docs: HOP v4.2.0 now supports ARM CPUs on Linux OS

### DIFF
--- a/_rsk/node/contribute/index.md
+++ b/_rsk/node/contribute/index.md
@@ -17,6 +17,9 @@ Compile and run your own node, step by step:
   - [On Linux](/rsk/node/contribute/linux)
   - [On Mac](/rsk/node/contribute/macos)
 
+> Note that starting from v4.2.0, Rootstock (RSK) now supports ARM CPUs on Linux OS. 
+Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
+
 After the previous steps have been completed, you can try these tutorials:
 
 - [From one node to a mining local network](/rsk/node/configure/for-mining)

--- a/_rsk/node/contribute/linux.md
+++ b/_rsk/node/contribute/linux.md
@@ -33,15 +33,18 @@ Recommended IDEs:
 
 ## Get the source code
 
-Using the installed command-line tool Git, you need to retrieve (or clone) the RskJ Github source code from [here](https://github.com/rsksmart/rskj).
+Using the installed command-line tool Git, you need to retrieve (or clone) the RSKj Github source code from [here](https://github.com/rsksmart/rskj).
 
-Run these commands on Git command line:
+Run these commands in the terminal:
 
 ```shell
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
 git checkout tags/IRIS-3.2.0 -b IRIS-3.2.0
 ```
+
+> Note that starting from v4.2.0, Rootstock (RSK) now supports ARM CPUs on Linux OS. 
+Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
 
 *Note:* It is better to download the code into a short path.
 


### PR DESCRIPTION
## What

- Added notice that HOP v4.2.0 now supports ARM CPUs on Linux OS

## Why

- [HOP 4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0)

## Refs

- [Task](https://www.notion.so/iovlabs/DevPortal-v4-2-0-now-supports-ARM-CPUs-on-Linux-OS-c15ab404aa22483ca02dec46f44c4f5f)
