### PR TITLE
Docs: Removed experimental notice for RocksDB

### DIFF
--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -66,7 +66,10 @@ This can be done in two ways:
 - Running the node with the `java` command, add `-Drsk.conf.file=path/to/your/file.conf`
 - Compiling the node with IntelliJ, add to VM options: `-Drsk.conf.file=path/to/your/file.conf`
 
-### Using RocksDB (Experimental)
+### Using RocksDB
+
+> IMPORTANT NOTICE: Starting from RSKj HOP v4.2.0, RocksDB is **no longer experimental**.  
+> - This release includes support for running RSKj on ARM processors, compatibility with Java 17, and fixes for JSON-RPC issues, among other things. Additionally, some features, such as Peer Scoring and support for RocksDB storage library, are now considered production-ready. Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
 
 By default, RSKj runs using [LevelDB](https://dbdb.io/db/leveldb).
 There is an option to use an alternate storage option,
@@ -103,8 +106,6 @@ and wants to run with `rocksdb` next.
 Note the use of the `--import` flag, which resets and re-imports the database.
 
 * `java -Dkeyvalue.datasource=rocksdb -jar ./rskj-core/build/libs/rskj-core-*-all.jar --testnet --import`
-
-**Warning:** This feature is considered experimental, do not use in production.
 
 ### Troubleshooting
 

--- a/_rsk/node/configure/index.md
+++ b/_rsk/node/configure/index.md
@@ -69,7 +69,7 @@ This can be done in two ways:
 ### Using RocksDB
 
 > IMPORTANT NOTICE: Starting from RSKj HOP v4.2.0, RocksDB is **no longer experimental**.  
-> - This release includes support for running RSKj on ARM processors, compatibility with Java 17, and fixes for JSON-RPC issues, among other things. Additionally, some features, such as Peer Scoring and support for RocksDB storage library, are now considered production-ready. Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
+> Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
 
 By default, RSKj runs using [LevelDB](https://dbdb.io/db/leveldb).
 There is an option to use an alternate storage option,

--- a/_rsk/node/configure/reference.md
+++ b/_rsk/node/configure/reference.md
@@ -9,6 +9,8 @@ render_features: 'tables-with-borders'
 
 See [CLI flags](../cli/) for command line flag options.
 
+> **Important Notice: RSKj HOP v4.2.0, RocksDB is no longer experimental. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
+
 ## Advanced Configuration
 
 For advanced configuration requirements, please refer to this
@@ -127,13 +129,11 @@ Selects the database that will be used to store the information.
 Possible options are:
 
 * `leveldb` (default)
-* `rocksdb` (experimental)
+* `rocksdb`
 
 If you wish to switch between the different storage options,
 for example from `leveldb` to `rocksdb` or vice versa, 
 you must **restart** the node with the import option each time you do so.
-
-**Warning:** This feature is considered experimental, do not use in production.
 
 ## vm
 

--- a/_rsk/node/contribute/index.md
+++ b/_rsk/node/contribute/index.md
@@ -17,8 +17,7 @@ Compile and run your own node, step by step:
   - [On Linux](/rsk/node/contribute/linux)
   - [On Mac](/rsk/node/contribute/macos)
 
-> Note that starting from v4.2.0, Rootstock (RSK) now supports ARM CPUs on Linux OS. 
-Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
+> **Important Notice: RSKj HOP v4.2.0 now supports ARM CPUs on Linux OS. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 After the previous steps have been completed, you can try these tutorials:
 

--- a/_rsk/node/contribute/linux.md
+++ b/_rsk/node/contribute/linux.md
@@ -43,10 +43,9 @@ cd rskj
 git checkout tags/IRIS-3.2.0 -b IRIS-3.2.0
 ```
 
-> Note that starting from v4.2.0, Rootstock (RSK) now supports ARM CPUs on Linux OS. 
-Read more in [RSK Hop Release v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0).
-
 *Note:* It is better to download the code into a short path.
+
+> **Important Notice: RSKj HOP v4.2.0 now supports ARM CPUs on Linux OS. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 ## Ensure the security chain
 

--- a/_rsk/node/peer-scoring-system.md
+++ b/_rsk/node/peer-scoring-system.md
@@ -2,11 +2,11 @@
 layout: rsk
 title: Peer Scoring System
 tags: rsk, rskj, node, config, peer, scoring, 
-description: " The peer scoring system protects the RSKJ node's resources from abusive or malicious peers"
+description: " The peer scoring system protects the RSKj node's resources from abusive or malicious peers"
 collection_order: 3000
 ---
 
-_**Warning: This feature is considered experimental, do not use it in production yet**_.
+> **Important Notice: RSKj HOP v4.2.0, RocksDB is no longer experimental. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 ## Introduction
 


### PR DESCRIPTION
## What

- Removed experimental notice for RocksDB
- Rewrite notice that HOP v4.2.0 now supports ARM CPUs on Linux OS

## Why

- #866 
- [HOP 4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0)

## Refs

- [Task](https://www.notion.so/iovlabs/DevPortal-RocksDB-no-longer-experimental-from-v4-2-0-1872c7f8bfa84ea6b59cf404eff053fa)
