### PR TITLE
docs: updated docs to RSKj Hop v4.2.0

### DIFF
--- a/_rsk/node/configure/verbosity.md
+++ b/_rsk/node/configure/verbosity.md
@@ -120,7 +120,7 @@ A logback configuration example can be downloaded from [here](https://github.com
 If you're running a node [using the release jar file](/rsk/node/install/java) use the following command:
 
 ```bash
-java -cp rskj-core-3.2.0-IRIS-all.jar -Dlogback.configurationFile=/full/path/to/logback.xml co.rsk.Start
+java -cp rskj-core-4.2.0-HOP-all.jar -Dlogback.configurationFile=/full/path/to/logback.xml co.rsk.Start
 ```
 
 #### Using logback with a compiled node

--- a/_rsk/node/contribute/linux.md
+++ b/_rsk/node/contribute/linux.md
@@ -40,7 +40,7 @@ Run these commands in the terminal:
 ```shell
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
-git checkout tags/IRIS-3.2.0 -b IRIS-3.2.0
+git checkout tags/HOP-4.2.0 -b HOP-4.2.0
 ```
 
 *Note:* It is better to download the code into a short path.

--- a/_rsk/node/contribute/macos.md
+++ b/_rsk/node/contribute/macos.md
@@ -52,7 +52,7 @@ Run these commands on Git command line:
 ```
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
-git checkout tags/IRIS-3.2.0 -b IRIS-3.2.0
+git checkout tags/HOP-4.2.0 -b HOP-4.2.0
 ```
 
 *Note:* It is better to download the code into a short path.

--- a/_rsk/node/install/java.md
+++ b/_rsk/node/install/java.md
@@ -26,7 +26,7 @@ To run the node:
   C:\> java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
   ```
 
-Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-3.2.0-IRIS-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-4.2.0-HOP-all.jar`
 
 ## Using import sync
 
@@ -67,7 +67,7 @@ to change the memory allocated to the process:
   C:\> java -Xmx4G -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
   ```
 
-Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-3.2.0-IRIS-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-4.2.0-HOP-all.jar`
 
 For further reference, check out the
 [`database.import` configuration setting](/rsk/node/configure/reference/#databaseimport).
@@ -102,7 +102,7 @@ If you want to change the network use these commands:
 - Testnet: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --testnet`
 - Regtest: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --regtest`
 
-Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-3.2.0-IRIS-all.jar`
+Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-4.2.0-HOP-all.jar`
 
 ## Video
 

--- a/_rsk/node/install/ubuntu.md
+++ b/_rsk/node/install/ubuntu.md
@@ -33,7 +33,7 @@ Choose `mainnet` and press `Enter` to continue
 
 ## Install via Direct Downloads
 
-You can also download the RSKj Ubuntu Package for Iris 3.2.0 and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
+You can also download the RSKj Ubuntu Package for Hop 4.2.0 and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
 
 ```shell
 # first install openjdk-8-jre or oracle-java8-installer

--- a/_rsk/node/reproducible.md
+++ b/_rsk/node/reproducible.md
@@ -13,7 +13,7 @@ Gradle building
 
 *Setup instructions for gradle build in docker container.*
 
-This is a deterministic build process used to build RSK node JAR file. It provides a way to be reasonable sure that the JAR is built from GitHub RskJ repository. It also makes sure that the same tested dependencies are used and statically built into the executable.
+This is a deterministic build process used to build RSK node JAR file. It provides a way to be reasonable sure that the JAR is built from GitHub Rskj repository. It also makes sure that the same tested dependencies are used and statically built into the executable.
 
 It's strongly suggested to follow the steps by yourself to avoid any kind of contamination in the process.
 
@@ -51,9 +51,9 @@ RUN apt-get update -y && \
     apt-get clean
 RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
 RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
-RUN git clone --single-branch --depth 1 --branch IRIS-3.2.0 https://github.com/rsksmart/rskj.git /code/rskj
+RUN git clone --single-branch --depth 1 --branch HOP-4.2.0 https://github.com/rsksmart/rskj.git /code/rskj
 RUN git clone https://github.com/rsksmart/reproducible-builds 
-RUN CP /Users/{$USER}/reproducible-builds/rskj/3.2.0-iris/Dockerfile  /Users/{$USER}/code/rskj
+RUN CP /Users/{$USER}/reproducible-builds/rskj/4.2.0-hop/Dockerfile  /Users/{$USER}/code/rskj
 WORKDIR /code/rskj
 RUN gpg --verify SHA256SUMS.asc
 RUN sha256sum --check SHA256SUMS.asc
@@ -69,9 +69,9 @@ brew install git gnupg openjdk@8 && \
     brew cleanup
 RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
 RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
-RUN git clone --single-branch --depth 1 --branch IRIS-3.2.0 https://github.com/rsksmart/rskj.git ./code/rskj
+RUN git clone --single-branch --depth 1 --branch HOP-4.2.0 https://github.com/rsksmart/rskj.git ./code/rskj
 RUN git clone https://github.com/rsksmart/reproducible-builds 
-RUN CP /Users/{$USER}/reproducible-builds/rskj/3.2.0-iris/Dockerfile  /Users/{$USER}/code/rskj
+RUN CP /Users/{$USER}/reproducible-builds/rskj/4.2.0-hop/Dockerfile  /Users/{$USER}/code/rskj
 RUN CD /code/rskj
 RUN gpg --verify SHA256SUMS.asc
 RUN sha256sum --check SHA256SUMS.asc
@@ -88,7 +88,7 @@ Run build
 To create a reproducible build, run:
 
 ```bash
-sudo docker build -t rskj-iris-3.2.0-reproducible .
+sudo docker build -t rskj-hop-4.2.0-reproducible .
 ```
 
 This may take several minutes to complete. What is done is:
@@ -101,7 +101,7 @@ This may take several minutes to complete. What is done is:
 To obtain SHA-256 checksums, run the following command:
 
 ```bash
-sudo docker run --rm rskj-iris-3.2.0-reproducible sha256sum /code/rskj/rskj-core/build/libs/rskj-core-3.2.0-IRIS-all.jar /code/rskj/rskj-core/build/libs/rskj-core-3.2.0-IRIS-sources.jar /code/rskj/rskj-core/build/libs/rskj-core-3.2.0-IRIS.jar /code/rskj/rskj-core/build/libs/rskj-core-3.2.0-IRIS.pom
+sudo docker run --rm rskj-hop-4.2.0-reproducible sha256sum /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP-all.jar /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP-sources.jar /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP.jar /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP.pom
 ```
 
 Check Results
@@ -111,10 +111,10 @@ After running the build process, a JAR file will be created in ```/code/rskj-cor
 You can check the SHA256 sum of the result file and compare it to the one published by RSK for that version.
 
 ```bash
-fe8432293600ba403e48e50253c5cdf322d8ec578b1984d17a26bf508a061c8a rskj-core-3.2.0-IRIS-all.jar
-751d87b110205357478a9bd7909413bf80afacd51bd10eaa502bec50fda5a410  rskj-core/build/libs/rskj-core-3.2.0-IRIS-sources.jar
-d2f6594272748de21f70025e59525f2ffc6159ce21b6751590c3b535953c4d29  rskj-core/build/libs/rskj-core-3.2.0-IRIS.jar
-7204272b35891dca1d962af811dec92889d9564e5b200b5a50485101557e2f36  rskj-core/build/libs/rskj-core-3.2.0-IRIS.pom
+556132bb0423f0ca0a101704d56daad17eaa124d4f88cf97ced8ca7ebcddb0b2 rskj-core-4.2.0-HOP-all.jar
+e0544eaea2068f3ec9a99628f82b0163fc31d7be5282c925e34797e74982f826  rskj-core/build/libs/rskj-core-4.2.0-HOP-sources.jar
+42b0f44d0c612506ed39e186ffd8790fe5f775ee6bcd7d7189e01b0b9439c06d  rskj-core/build/libs/rskj-core-4.2.0-HOP.jar
+9160b4e02eef885afc672005a33e10ced8e4b9a7792039faf7f7a86880c165b0  rskj-core/build/libs/rskj-core-4.2.0-HOP.pom
 ```
 
 For SHA256 sum of older versions check the [releases page](https://github.com/rsksmart/rskj/releases).

--- a/libraries/rsk-precompiled-abis/index.md
+++ b/libraries/rsk-precompiled-abis/index.md
@@ -70,3 +70,8 @@ If the version to be installed is not defined in the command line, the version w
 | 3.0.0-IRIS      | IRIS-3.0.0    |
 | 3.1.0-IRIS      | IRIS-3.1.0    |
 | 3.2.0-IRIS      | IRIS-3.2.0    |
+| 3.3.0-IRIS      | IRIS-3.3.0    |
+| 4.0.0-HOP       |  HOP-4.0.0    |
+| 4.1.0-HOP       |  HOP-4.1.0    |
+| 4.1.1-HOP       |  HOP-4.1.1    |
+| 4.2.0-HOP       |  HOP-4.2.0    |


### PR DESCRIPTION
## What

- Updated docs to RSKj Hop v4.2.0

## Why

- docs maintenance
- RSKj Hop v4.2.0 release

## Refs

- [Task](https://www.notion.so/iovlabs/DevPortal-Update-docs-to-HOP-v4-2-0-c75185c4173449daade54a155c849704)
