### PR TITLE
proj: minor: exclude package.json and README.md from build outputs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,8 @@ exclude:
   - vendor
   - assets/img/windowsInstall/
   - node_modules
+  - package.json
+  - README.md
 
 plugins:
  - jekyll-last-modified-at


### PR DESCRIPTION
## What

- updated exclude files from build outputs dir (`package.json`, `README.md`)

## Why

- they are not necessary

## Refs

- NIL
