### PR TITLE
Updated Docs to RSKj FINGERROOT 5.2.0

### DIFF
--- a/_quick-start/step1-install-rsk-local-node.md
+++ b/_quick-start/step1-install-rsk-local-node.md
@@ -98,27 +98,27 @@ it is always good practice to verify that your copy is legitimate.
 Let's compute the checksum using the following command:
 
 ```shell
-sha256sum rskj-core-3.1.0-IRIS-all.jar
+sha256sum rskj-core-rskj-core-5.2.0-FINGERROOT-all.jar
 ```
 
 For this version, the output should look like this:
 
 ```shell
-43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0 *rskj-core-3.1.0-IRIS-all.jar
+70ae5209720ad6477c1c32d8a8d94e29ebb0db25d57e9903546519d614eddf9f  rskj-core-5.2.0-FINGERROOT-all.jar
 ```
 
 On Windows, use this command instead:
 
 ```windows-command-prompt
-C:\>certutil -hashfile rskj-core-3.1.0-IRIS-all.jar SHA256
+C:\>certutil -hashfile rskj-core-5.2.0-FINGERROOT-all.jar SHA256
 
 ```
 
 For this version, the output on windows should look like this:
 
 ```windows-command-prompt
-SHA256 hash of rskj-core-3.1.0-IRIS-all.jar:
-43149abce0a737341a0b063f2016a1e73dae19b8af8f2e54657326ac8eedc8a0
+SHA256 hash of rskj-core-5.2.0-FINGERROOT-all.jar:
+70ae5209720ad6477c1c32d8a8d94e29ebb0db25d57e9903546519d614eddf9f
 CertUtil: -hashfile command completed successfully.
 
 ```
@@ -136,7 +136,6 @@ To run the node:
 
 ```shell
 java -classpath <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
-
 ```
 
 (Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file).
@@ -144,7 +143,7 @@ java -classpath <PATH-TO-THE-RSKJ-JAR> -Drpc.providers.web.cors=* -Drpc.provider
 > Example:
 >
 > ```windows-command-prompt
-> C:\>java -classpath C:\RSK\node\rskj-core-3.1.0-IRIS-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
+> C:\>java -classpath C:\RSK\node\rskj-core-5.2.0-FINGERROOT-all.jar -Drpc.providers.web.cors=* -Drpc.providers.web.ws.enabled=true co.rsk.Start --regtest
 >
 > ```
 

--- a/develop/libs/rsk-precompilied-abis.md
+++ b/develop/libs/rsk-precompilied-abis.md
@@ -58,7 +58,7 @@ bridge.methods.getFederationAddress().call().then(console.log);
 
 # Important note
 
-If the version to be installed is not defined in the command line, the version will correspond to the latest version in PAPYRUS.
+If the version to be installed is not defined in the command line, the version will correspond to the latest version in [rskj releases page](https://github.com/rsksmart/reproducible-builds/tree/master/rskj).
 
 # Versioning table
 
@@ -73,7 +73,12 @@ If the version to be installed is not defined in the command line, the version w
 | 3.1.0-IRIS      | IRIS-3.1.0    |
 | 3.2.0-IRIS      | IRIS-3.2.0    |
 | 3.3.0-IRIS      | IRIS-3.3.0    |
-| 4.0.0-HOP       |  HOP-4.0.0    |
-| 4.1.0-HOP       |  HOP-4.1.0    |
-| 4.1.1-HOP       |  HOP-4.1.1    |
-| 4.2.0-HOP       |  HOP-4.2.0    |
+| 4.0.0-HOP       | HOP-4.0.0    |
+| 4.1.0-HOP       | HOP-4.1.0    |
+| 4.1.1-HOP       | HOP-4.1.1    |
+| 4.2.0-HOP       | HOP-4.2.0    |
+| 4.3.0-HOP       | HOP-4.3.0    |
+| 4.4.0-HOP       | HOP-4.4.0    |
+| 5.0.0-fingerroot | FINGERROOT-5.0.0 |
+| 5.1.0-fingerroot | FINGERROOT-5.1.0 |
+| 5.2.0-fingerroot | FINGERROOT-5.2.0 |

--- a/develop/tutorials/workshop-prereqs.md
+++ b/develop/tutorials/workshop-prereqs.md
@@ -138,10 +138,10 @@ mkdir -p ~/code/rsk/rskj-node
 cd ~/code/rsk/rskj-node
 curl \
   -L \
-  https://github.com/rsksmart/rskj/releases/download/HOP-4.2.0/rskj-core-4.2.0-HOP-all.jar \
-  > ./rskj-core-4.2.0-HOP-all.jar
-sha256sum rskj-core-4.2.0-HOP-all.jar
-# 556132bb0423f0ca0a101704d56daad17eaa124d4f88cf97ced8ca7ebcddb0b2 rskj-core-4.2.0-HOP-all.jar
+  https://github.com/rsksmart/rskj/releases/download/FINGERROOT-5.2.0/rskj-core-5.2.0-FINGERROOT-all.jar \
+  > ./rskj-core-5.2.0-FINGERROOT-all.jar
+sha256sum rskj-core-5.2.0-FINGERROOT-all.jar
+# 556132bb0423f0ca0a101704d56daad17eaa124d4f88cf97ced8ca7ebcddb0b2 rskj-core-5.2.0-FINGERROOT-all.jar
 
 ```
 
@@ -154,7 +154,7 @@ For the purposes of this workshop,
 we will run RSKj on Regtest.
 
 ```shell
-java -cp rskj-core-4.2.0-HOP-all.jar  -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp rskj-core-5.2.0-FINGERROOT-all.jar  -Drpc.providers.web.cors=* co.rsk.Start --regtest
 
 ```
 

--- a/kb/rskj-for-developers.md
+++ b/kb/rskj-for-developers.md
@@ -32,7 +32,7 @@ Running RSKj in Regtest mode is the best fit for these needs.
 java \
   -Drpc.providers.web.cors='*' \
   -Dminer.client.autoMine=true \
-  -cp rskj-core-4.1.0-HOP-all.jar \
+  -cp rskj-core-5.2.0-FINGERROOT-all.jar \
   co.rsk.Start \
   --regtest \
   --reset

--- a/libraries/rsk-precompiled-abis/index.md
+++ b/libraries/rsk-precompiled-abis/index.md
@@ -75,3 +75,8 @@ If the version to be installed is not defined in the command line, the version w
 | 4.1.0-HOP       |  HOP-4.1.0    |
 | 4.1.1-HOP       |  HOP-4.1.1    |
 | 4.2.0-HOP       |  HOP-4.2.0    |
+| 4.3.0-HOP       | HOP-4.3.0    |
+| 4.4.0-HOP       | HOP-4.4.0    |
+| 5.0.0-fingerroot | FINGERROOT-5.0.0 |
+| 5.1.0-fingerroot | FINGERROOT-5.1.0 |
+| 5.2.0-fingerroot | FINGERROOT-5.2.0 |

--- a/rsk/node/architecture/json-rpc.md
+++ b/rsk/node/architecture/json-rpc.md
@@ -11,7 +11,7 @@ Rootstock (RSK) currently supports the following:
 
 - [JSON RPC methods](#json-rpc-methods)
 - [Management API methods](#management-api-methods)
-- [RPC PUB SUB methods](#rpc-pub-sub-methods)\
+- [RPC PUB SUB methods](#rpc-pub-sub-methods)
 
 See the JSON-RPC configuration limits and usage:
 - [JSON RPC Configurable Limits](#configuration-of-limits-for-json-rpc-interface)

--- a/rsk/node/configure/index.md
+++ b/rsk/node/configure/index.md
@@ -68,7 +68,7 @@ This can be done in two ways:
 ### Using RocksDB
 
 - **Important Info:**
-  > - Starting from RSKj HOP v4.2.0, RocksDB is no longer experimental. As of the most recent version, RocksDB has now been made the default storage library, replacing LevelDB. This change was made to tackle maintainability and performance issues of LevelDB.
+  > - Starting from [RSKj HOP v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0), RocksDB is no longer experimental. As of the most recent version, RocksDB has now been made the default storage library, replacing LevelDB. This change was made to tackle maintainability and performance issues of LevelDB.
   > - Previously, RSKj ran using [LevelDB](https://dbdb.io/db/leveldb) by default, with the option to switch to [RocksDB](http://rocksdb.org/). Now, RocksDB is the default storage option, aiming to enable higher performance within the RSKj nodes.
 
 #### Get Started

--- a/rsk/node/configure/reference.md
+++ b/rsk/node/configure/reference.md
@@ -10,7 +10,7 @@ render_features: 'tables-with-borders'
 
 See [CLI flags](../cli/) for command line flag options.
 
-> **Important Notice: RSKj HOP v4.2.0, RocksDB is no longer experimental. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
+> **Important Notice: From [RSKj HOP v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0), RocksDB is no longer experimental. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 ## Advanced Configuration
 

--- a/rsk/node/configure/verbosity.md
+++ b/rsk/node/configure/verbosity.md
@@ -121,7 +121,7 @@ A logback configuration example can be downloaded from [here](https://github.com
 If you're running a node [using the release jar file](/rsk/node/install/java) use the following command:
 
 ```bash
-java -cp rskj-core-4.2.0-HOP-all.jar -Dlogback.configurationFile=/full/path/to/logback.xml co.rsk.Start
+java -cp rskj-core-5.2.0-FINGERROOT-all.jar -Dlogback.configurationFile=/full/path/to/logback.xml co.rsk.Start
 ```
 
 #### Using logback with a compiled node

--- a/rsk/node/contribute/index.md
+++ b/rsk/node/contribute/index.md
@@ -17,7 +17,7 @@ Compile and run your own node, step by step:
   - [On Linux](/rsk/node/contribute/linux)
   - [On Mac](/rsk/node/contribute/macos)
 
-> **Important Notice: RSKj HOP v4.2.0 now supports ARM CPUs on Linux OS. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
+> **Important Notice: [RSKj HOP v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0) now supports ARM CPUs on Linux OS. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 After the previous steps have been completed, you can try these tutorials:
 

--- a/rsk/node/contribute/linux.md
+++ b/rsk/node/contribute/linux.md
@@ -40,12 +40,12 @@ Run these commands in the terminal:
 ```shell
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
-git checkout tags/HOP-4.2.0 -b HOP-4.2.0
+git checkout tags/FINGERROOT-5.2.0 -b FINGERROOT-5.2.0
 ```
 
 *Note:* It is better to download the code into a short path.
 
-> **Important Notice: RSKj HOP v4.2.0 now supports ARM CPUs on Linux OS. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
+> **Important Notice: From [RSKj HOP v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0), ARM CPUs on Linux OS is now supported. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 ## Ensure the security chain
 

--- a/rsk/node/contribute/macos.md
+++ b/rsk/node/contribute/macos.md
@@ -52,7 +52,7 @@ Run these commands on Git command line:
 ```
 git clone --recursive https://github.com/rsksmart/rskj.git
 cd rskj
-git checkout tags/HOP-4.2.0 -b HOP-4.2.0
+git checkout tags/FINGERROOT-5.2.0 -b FINGERROOT-5.2.0
 ```
 
 *Note:* It is better to download the code into a short path.

--- a/rsk/node/install/index.md
+++ b/rsk/node/install/index.md
@@ -13,7 +13,7 @@ permalink: /rsk/node/install/
 
 Ensure that your system meets the [minimum requirements](/rsk/node/install/requirements/) before installing the RSK nodes on it.
 
-### Install RSK Node and Join the RSK Hop Mainnet
+### Install RSK Node and Join the RSK Mainnet
 
 RSK nodes can be installed on all major platforms, including Linux, Windows, and Mac. Here we provide step-by-step instructions for all supported platforms. Depending on your network performance, it usually takes 10 to 15 mins to setup a working node on Mainnet.
 

--- a/rsk/node/install/operating-systems/java.md
+++ b/rsk/node/install/operating-systems/java.md
@@ -30,7 +30,7 @@ To run the node:
   C:\> java -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start
   ```
 
-Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-4.2.0-HOP-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-5.2.0-FINGERROOT-all.jar`
 
 ## Using import sync
 
@@ -71,7 +71,7 @@ to change the memory allocated to the process:
   C:\> java -Xmx4G -cp <PATH-TO-THE-RSKJ-JAR> co.rsk.Start --import
   ```
 
-Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-4.2.0-HOP-all.jar`
+Replace `<PATH-TO-THE-RSKJ-JAR>` with your path to the JAR file. As an example: `C:/RskjCode/rskj-core-5.2.0-FINGERROOT-all.jar`
 
 For further reference, check out the
 [`database.import` configuration setting](/rsk/node/configure/reference/#databaseimport).
@@ -106,7 +106,7 @@ If you want to change the network use these commands:
 - Testnet: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --testnet`
 - Regtest: `java -cp <PATH-TO-THE-RSKJ-FATJAR> co.rsk.Start --regtest`
 
-Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-4.2.0-HOP-all.jar`
+Replace `<PATH-TO-THE-RSKJ-FATJAR>` with your path to the jar file. As an example: `C:/RskjCode/rskj-core-5.2.0-FINGERROOT-all.jar`
 
 ## Video
 

--- a/rsk/node/install/operating-systems/ubuntu.md
+++ b/rsk/node/install/operating-systems/ubuntu.md
@@ -33,7 +33,7 @@ Choose `mainnet` and press `Enter` to continue
 
 ## Install via Direct Downloads
 
-You can also download the RSKj Ubuntu Package for Hop 4.2.0 and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
+You can also download the RSKj Ubuntu Package for the latest RSKj release `FINGERROOT 5.2.0` and install it with the `dpkg` command. Follow this [download link](https://launchpad.net/~rsksmart/+archive/ubuntu/rskj/+packages) to download the matching package for your ubuntu system.
 
 ```shell
 # first install openjdk-8-jre or oracle-java8-installer

--- a/rsk/node/peer-scoring-system.md
+++ b/rsk/node/peer-scoring-system.md
@@ -7,7 +7,7 @@ description: " The peer scoring system protects the RSKj node's resources from a
 menu_order: 11
 ---
 
-> **Important Notice: RSKj HOP v4.2.0, RocksDB is no longer experimental. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
+> **Important Notice: From [RSKj HOP v4.2.0](https://github.com/rsksmart/rskj/releases/tag/HOP-4.2.0), RocksDB is no longer experimental. See [using RocksDB](/rsk/node/configure/#using-rocksdb)**.
 
 ## Introduction
 

--- a/rsk/node/reproducible.md
+++ b/rsk/node/reproducible.md
@@ -52,7 +52,7 @@ Create a ```Dockerfile``` to setup the build environment
       apt-get clean
   RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
   RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
-  RUN git clone --single-branch --depth 1 --branch HOP-4.2.0 https://github.com/rsksmart/rskj.git /code/rskj
+  RUN git clone --single-branch --depth 1 --branch FINGERROOT-5.2.0 https://github.com/rsksmart/rskj.git /code/rskj
    RUN git clone https://github.com/rsksmart/reproducible-builds 
   RUN CP /Users/{$USER}/reproducible-builds/rskj/5.2.0-fingerroot/Dockerfile  /Users/{$USER}/code/rskj
   WORKDIR /code/rskj

--- a/rsk/node/reproducible.md
+++ b/rsk/node/reproducible.md
@@ -53,8 +53,8 @@ Create a ```Dockerfile``` to setup the build environment
   RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
   RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
   RUN git clone --single-branch --depth 1 --branch HOP-4.2.0 https://github.com/rsksmart/rskj.git /code/rskj
-  RUN git clone https://github.com/rsksmart/reproducible-builds 
-  RUN CP /Users/{$USER}/reproducible-builds/rskj/4.2.0-hop/Dockerfile  /Users/{$USER}/code/rskj
+   RUN git clone https://github.com/rsksmart/reproducible-builds 
+  RUN CP /Users/{$USER}/reproducible-builds/rskj/5.2.0-fingerroot/Dockerfile  /Users/{$USER}/code/rskj
   WORKDIR /code/rskj
   RUN gpg --verify SHA256SUMS.asc
   RUN sha256sum --check SHA256SUMS.asc
@@ -70,9 +70,9 @@ Create a ```Dockerfile``` to setup the build environment
       brew cleanup
   RUN gpg --keyserver https://secchannel.rsk.co/release.asc --recv-keys 1A92D8942171AFA951A857365DECF4415E3B8FA4
   RUN gpg --finger 1A92D8942171AFA951A857365DECF4415E3B8FA4
-  RUN git clone --single-branch --depth 1 --branch HOP-4.2.0 https://github.com/rsksmart/rskj.git ./code/rskj
+  RUN git clone --single-branch --depth 1 --branch FINGERROOT-5.2.0 https://github.com/rsksmart/rskj.git ./code/rskj
   RUN git clone https://github.com/rsksmart/reproducible-builds 
-  RUN CP /Users/{$USER}/reproducible-builds/rskj/4.2.0-hop/Dockerfile  /Users/{$USER}/code/rskj
+  RUN CP /Users/{$USER}/reproducible-builds/rskj/5.2.0-fingerroot/Dockerfile  /Users/{$USER}/code/rskj
   RUN CD /code/rskj
   RUN gpg --verify SHA256SUMS.asc
   RUN sha256sum --check SHA256SUMS.asc
@@ -80,17 +80,29 @@ Create a ```Dockerfile``` to setup the build environment
   RUN ./gradlew clean build -x test   
   ```
 
-If you are not familiar with Docker or the ```Dockerfile``` format: what this does is use the Ubuntu 16.04 base image and install ```git```, ```curl```, ```gnupg-curl``` and ```openjdk-8-jdk```, required for building RSK node.
+**Response:**
+
+You should get the following as the final response, 
+after running the above steps:
+
+```bash
+BUILD SUCCESSFUL in 55s
+14 actionable tasks: 13 executed, 1 up-to-date
+```
+
+If you are not familiar with Docker or the ```Dockerfile``` format: what this does is use the Ubuntu 16.04 base image and install ```git```, ```curl```, ```gnupg-curl``` and ```openjdk-8-jdk```, required for building the RSK node.
 
 
 Run build
 ---------
 
-To create a reproducible build, run:
+To create a reproducible build, run the command below in the same directory:
 
 ```bash
-sudo docker build -t rskj-hop-4.2.0-reproducible .
+$ docker build -t rskj/5.2.0-fingerroot .     
 ```
+
+> if you run into any problems, ensure you're running the commands on the right folder and also ensure docker daemon is running is updated to the recent version.
 
 This may take several minutes to complete. What is done is:
 - Place in the RSKj repository root because we need Gradle and the project.
@@ -99,25 +111,53 @@ This may take several minutes to complete. What is done is:
 - `./gradlew clean build -x test` builds without running tests.
 
 
-To obtain SHA-256 checksums, run the following command:
+Verify Build
+------------
+
+The last step of the build prints the `sha256sum` of the files, to obtain `SHA-256` checksums, run the following command in the same directory as shown above:
 
 ```bash
-sudo docker run --rm rskj-hop-4.2.0-reproducible sha256sum /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP-all.jar /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP-sources.jar /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP.jar /code/rskj/rskj-core/build/libs/rskj-core-4.2.0-HOP.pom
+$ docker run --rm rskj/5.2.0-fingerroot sh -c 'sha256sum * | grep -v javadoc.jar'
 ```
 
 Check Results
 -------------
-After running the build process, a JAR file will be created in ```/code/rskj-core/build/libs/```, into the docker container.
+After running the build process, a JAR file will be created in ```/rskj/rskj-core/build/libs/```, into the docker container.
 
 You can check the SHA256 sum of the result file and compare it to the one published by RSK for that version.
 
 ```bash
-556132bb0423f0ca0a101704d56daad17eaa124d4f88cf97ced8ca7ebcddb0b2 rskj-core-4.2.0-HOP-all.jar
-e0544eaea2068f3ec9a99628f82b0163fc31d7be5282c925e34797e74982f826  rskj-core/build/libs/rskj-core-4.2.0-HOP-sources.jar
-42b0f44d0c612506ed39e186ffd8790fe5f775ee6bcd7d7189e01b0b9439c06d  rskj-core/build/libs/rskj-core-4.2.0-HOP.jar
-9160b4e02eef885afc672005a33e10ced8e4b9a7792039faf7f7a86880c165b0  rskj-core/build/libs/rskj-core-4.2.0-HOP.pom
+70ae5209720ad6477c1c32d8a8d94e29ebb0db25d57e9903546519d614eddf9f  rskj-core-5.2.0-FINGERROOT-all.jar
+6ed2bcb287e6b9e61bb99b65307e2e51b4231a92070fed4569443981fc2597ce  rskj-core-5.2.0-FINGERROOT-sources.jar
+3b1dd7d624137fb1bcc133927a7357eed3228457e8db29f17cf0a193370bbe12  rskj-core-5.2.0-FINGERROOT.jar
+4d588eae64108680c6ae6e895e2d6d4a07cdd05a31718d6f4a34870153a51d5a  rskj-core-5.2.0-FINGERROOT.module
+3903f17a97e7dbd55bac0dd02030f5297e364280e2b7a856aaf03b4d327dce3c  rskj-core-5.2.0-FINGERROOT.pom
 ```
 
 For SHA256 sum of older versions check the [releases page](https://github.com/rsksmart/rskj/releases).
 
 If you check inside the JAR file, you will find that the dates of the files are the same as the version commit you are using.
+
+Run RSK Node (Optional)
+======================
+
+To start an RSK Node using the Dockerfile, run the command below:
+
+```bash
+$ docker run -d rskj/5.2.0-fingerroot
+```
+
+Extract JAR from image (Optional)
+================================
+
+```bash
+$ cid=$(docker run -d rskj/5.2.0-fingerroot /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```
+
+More Resources
+==============
+
+* See [Reproducible builds](https://github.com/rsksmart/reproducible-builds/tree/master/rskj)
+* Check out the [latest rskj releases](https://github.com/rsksmart/rskj/releases)

--- a/tutorials/workshop-prereqs.md
+++ b/tutorials/workshop-prereqs.md
@@ -136,11 +136,10 @@ mkdir -p ~/code/rsk/rskj-node
 cd ~/code/rsk/rskj-node
 curl \
   -L \
-  https://github.com/rsksmart/rskj/releases/download/HOP-4.2.0/rskj-core-4.2.0-HOP-all.jar \
-  > ./rskj-core-4.2.0-HOP-all.jar
-sha256sum rskj-core-4.2.0-HOP-all.jar
-# 556132bb0423f0ca0a101704d56daad17eaa124d4f88cf97ced8ca7ebcddb0b2 rskj-core-4.2.0-HOP-all.jar
-
+  https://github.com/rsksmart/rskj/releases/download/FINGERROOT-5.2.0/rskj-core-5.2.0-FINGERROOT-all.jar \
+  > ./rskj-core-5.2.0-FINGERROOT-all.jar
+sha256sum rskj-core-5.2.0-FINGERROOT-all.jar
+# 556132bb0423f0ca0a101704d56daad17eaa124d4f88cf97ced8ca7ebcddb0b2 rskj-core-5.2.0-FINGERROOT-all.jar
 ```
 
 > Note: When installing and running the RSKj node,
@@ -152,7 +151,7 @@ For the purposes of this workshop,
 we will run RSKj on Regtest.
 
 ```shell
-java -cp rskj-core-4.2.0-HOP-all.jar  -Drpc.providers.web.cors=* co.rsk.Start --regtest
+java -cp rskj-core-5.2.0-FINGERROOT-all.jar  -Drpc.providers.web.cors=* co.rsk.Start --regtest
 
 ```
 


### PR DESCRIPTION
## What

- Update Docs to RSKj FINGERROOT 5.2.0

## Why

- New RSKj release
- Docs maintenance

## Refs

- [Task](https://rsklabs.atlassian.net/browse/D1-562)
