### PR TITLE
Rollup Docs Nav Fixes

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -18,3 +18,4 @@ section_title: Guides
 - [Create, Deploy, and View NFT project on RSK](/guides/nft/)
 - [Flyover Protocol User Guide](/guides/flyover/)
 - [2 Way Peg App User Guide](/guides/two-way-peg-app/)
+- [RIF Rollup User Guides](/guides/rif-rollup/)

--- a/guides/rif-rollup/index.md
+++ b/guides/rif-rollup/index.md
@@ -3,7 +3,7 @@ menu_order: 200
 section_title: User Guide | RIF Rollup
 menu_title: User Guide
 layout: rsk
-title: RIF Rollup Documentation | Tutorials
+title: RIF Rollup | Tutorials
 description: RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology.
 tags: rif, aggregation, zkSync, rollup, rif-rollup
 ---

--- a/rif/rollup/dapps.md
+++ b/rif/rollup/dapps.md
@@ -1,8 +1,8 @@
 ---
 menu_order: 300
-menu_title: RIF Rollup | dApps on RIF Rollup
+menu_title: dApps on RIF Rollup
 layout: rsk
-title: RIF Rollup Documentation | dApps
+title: RIF Rollup | dApps
 description: RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology. See the dApps ported on Rootstock.
 tags: rif, aggregation, zksync, rollup
 ---

--- a/rif/rollup/dev-reference/design.md
+++ b/rif/rollup/dev-reference/design.md
@@ -1,8 +1,8 @@
 ---
-menu_order: 500
+menu_order: 300
 menu_title: Design and Architecture
 layout: rsk
-title: RIF Rollup Documentation | Design and Architecture
+title: RIF Rollup | Design and Architecture
 description: zkSync main architecture and design
 tags: rif, aggregation, zksync, rollup
 ---

--- a/rif/rollup/dev-reference/index.md
+++ b/rif/rollup/dev-reference/index.md
@@ -1,8 +1,8 @@
 ---
-menu_order: 300
+menu_order: 1200
 menu_title: Developer Reference Guide
 layout: rsk
-title: Developer Reference Guide | Using the APIs and SDK
+title: Developer Reference Guide
 description: The developer reference section provides all information you need to use and integrate the RIF Rollup using the SDKs available. 
 tags: rif, aggregation, zksync, rollup
 ---

--- a/rif/rollup/dev-reference/sdk.md
+++ b/rif/rollup/dev-reference/sdk.md
@@ -1,8 +1,8 @@
 ---
-menu_order: 400
+menu_order: 200
 menu_title: SDKs and APIs
 layout: rsk
-title: RIF Rollup Documentation | Using the API and SDKs
+title: RIF Rollup | Using the API and SDKs
 description: RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology. See the dApps ported to Rootstock.
 tags: rif, aggregation, zksync, rollup, sdks, apis, rif-rollup
 render_features: 'tables-with-borders'

--- a/rif/rollup/dev-reference/starter-kit.md
+++ b/rif/rollup/dev-reference/starter-kit.md
@@ -1,8 +1,8 @@
 ---
-menu_order: 600
+menu_order: 400
 menu_title: RIF Rollup Starter Kit
 layout: rsk
-title: RIF Rollup - Starter Kit
+title: RIF Rollup | Starter Kit
 description: A step-by-step guide to setup and create your own dapp
 tags: rif, aggregation, zksync, rollup
 ---

--- a/rif/rollup/dev-reference/troubleshooting.md
+++ b/rif/rollup/dev-reference/troubleshooting.md
@@ -1,8 +1,8 @@
 ---
-menu_order: 700
+menu_order: 500
 menu_title: Troubleshooting
 layout: rsk
-title: RIF Rollup - Troubleshooting and Common Errors
+title: RIF Rollup | Troubleshooting and Common Errors
 description: RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology.
 tags: rif, aggregation, zksync, rollup, troubleshooting
 render_features: 'collapsible'

--- a/rif/rollup/faqs.md
+++ b/rif/rollup/faqs.md
@@ -2,7 +2,7 @@
 menu_order: 400
 menu_title: FAQs
 layout: rsk
-title: RIF Rollup - Frequently Asked Questions
+title: Frequently Asked Questions
 description: A list of frequently asked questions on RIF Rollup
 tags: rif, aggregation, zksync, rollup, faqs
 render_features: 'collapsible'

--- a/rif/rollup/glossary.md
+++ b/rif/rollup/glossary.md
@@ -2,7 +2,7 @@
 menu_order: 500
 menu_title: Glossary
 layout: rsk
-title: RIF Rollup Documentation | Glossary
+title: RIF Rollup | Glossary
 description: RIF Rollup Terms and Meaning
 tags: rif, aggregation, zksync, rollup, glossary, rif-rollup
 ---

--- a/rif/rollup/index.md
+++ b/rif/rollup/index.md
@@ -1,7 +1,7 @@
 ---
 menu_order: 1100
-section_title: RIF Rollup Docs
-menu_title: RIF Rollup Documentation
+section_title: RIF Rollup
+menu_title: Introduction
 layout: rsk
 title: RIF Rollup Documentation | Introduction
 description: RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology.
@@ -44,9 +44,9 @@ Here are some important links to take note of:
 * RIF Rollup Wallet: Check your balances, NFTs, transactions history and contacts. See the [RIF Rollup Wallet - Testnet](https://wallet.testnet.rollup.rif.technology/)
 * RIF Rollup Explorer: Everything you need to explore all transactions and blocks on RIF Rollup. See the [RIF Rollup Explorer - Testnet](https://explorer.testnet.rollup.rif.technology/)
 
-See the [Glossary section](glossary) for definitions of terms.
 
-----
+Table of Contents
+-----------------
 
 <div class="container the-stack">
  <div class="row rif_blue_text">
@@ -58,23 +58,23 @@ See the [Glossary section](glossary) for definitions of terms.
         <p>All you need to know about the RIF Rollup</p>
       </div>
   </div>
-   <div class="col">
+  <div class="col">
       <div class="rns-index-box">
-        <a href="dev-reference">Developer Reference Guide</a>
+        <a href="./dev-reference/">Developer Reference Guide</a>
         <br />
         <br />
         <p>Get started building on RIF Rollup</p>
       </div>
   </div>
-  <div class="row rif_blue_text">
-    <div class="col">
+  <div class="col">
       <div class="rns-index-box">
-        <a href="design">Design and Architecture</a>
+        <a href="./dev-reference/design">Design and Architecture</a>
         <br />
         <br />
         <p>Learn more about the RIF Rollup architecture</p>
       </div>
-    </div>
+  </div>
+  <div class="row rif_blue_text">
     <div class="col">
       <div class="rns-index-box">
         <a href="dapps">dApps</a>
@@ -82,45 +82,51 @@ See the [Glossary section](glossary) for definitions of terms.
         <br />
         <p>Take a look at the dapps currently available on Rootstock (RSK)</p>
       </div>
-    </div>
   </div>
-   <div class="row rif_blue_text">
-    <div class="col">
+  <div class="col">
       <div class="rns-index-box">
-        <a href="/guides/rif-rollup/" rel="noopener noreferrer" >Tutorials</a>
+        <a href="/guides/rif-rollup/">Tutorials</a>
         <br />
         <br />
-        <p>A collection of tutorials and guides on how to perform selected tasks on RIF Rollup..</p>
+        <p>A collection of tutorials and guides on how to perform selected tasks on RIF Rollup.</p>
       </div>
     </div>
+  </div>
+  <div class="col">
+    <div class="rns-index-box">
+      <a href="./dev-reference/starter-kit">Starter Kit (Coming soon)</a>
+      <br />
+      <br />
+      <p>This kit comes with everything you need to start using the RIF Rollup inside your applications.</p>
+    </div>
+  </div>
+  <div class="col">
+    <div class="rns-index-box">
+        <a href="security">Security</a>
+        <br />
+        <br />
+        <p>See how security is achieved with the RIF Rollup.</p>
+    </div>
+  </div>
   <div class="row rif_blue_text">
     <div class="col">
       <div class="rns-index-box">
-        <a href="starter-kit" rel="noopener noreferrer" >Starter Kit (Coming soon)</a>
-        <br />
-        <br />
-        <p>This kit comes with everything you need to start using the RIF Rollup inside your applications. It also includes all the configuration required to deploy to different networks on Rootstock.</p>
-      </div>
-    </div>
-    <div class="col">
-      <div class="rns-index-box">
-        <a href="faqs">Frequently Asked Questions</a>
+        <a href="faqs" rel="noopener noreferrer" >Frequently Asked Questions</a>
         <br />
         <br />
         <p>A set of frequently asked questions about the RIF Rollup.</p>
       </div>
     </div>
   </div>
-   <div class="col">
-      <div class="rns-index-box">
-        <a href="troubleshooting">Troubleshooting and Common Errors</a>
-        <br />
-        <br />
-        <p>Find common errors and how to troubleshoot them.</p>
+  <div class="col">
+    <div class="rns-index-box">
+      <a href="./dev-reference/troubleshooting">Troubleshooting and Common Errors</a>
+      <br />
+      <br />
+      <p>Find common errors and how to troubleshoot them.</p>
       </div>
-    </div>
   </div>
-   <div class="col">
+  <div class="col">
       <div class="rns-index-box">
         <a href="glossary">Glossary</a>
         <br />

--- a/rif/rollup/overview.md
+++ b/rif/rollup/overview.md
@@ -2,7 +2,7 @@
 menu_order: 200
 menu_title: Overview
 layout: rsk
-title: RIF Rollup Documentation | Overview
+title: RIF Rollup | Overview
 description: RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology.
 tags: rif, aggregation, zksync, rollup, rif-rollup
 ---


### PR DESCRIPTION
## What

- Rollup Docs Nav Fixes

## Why

- left navigation now showing some pages

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
