### PR TITLE
Removed the repetition in the RNS user guide

### DIFF
--- a/content/rsk-devportal/rif/rns/guide/intro.md
+++ b/content/rsk-devportal/rif/rns/guide/intro.md
@@ -7,7 +7,7 @@ description: "What is RNS, and how to use the testnet"
 tags: rns, guide, rns-user-guide
 ---
 
-RIF Name Service is a decentralized domain service built on top of Rootstock (RSK) blockchain. One of the ways to operate with the service is through the application known as the manager. One of the ways to operate with the service is through the application known as the manager, which allows registering and managing domains from the internet browser using an extension wallet. This guide details each operation available in the [RNS manager](https://manager.rns.rifos.org).
+RIF Name Service is a decentralized domain service built on top of Rootstock (RSK) blockchain. One of the ways to operate with the service is through the application known as the manager, which allows registering and managing domains from the internet browser using an extension wallet. This guide details each operation available in the [RNS manager](https://manager.rns.rifos.org).
 
 
 - [Setup](/rif/rns/guide/setup/)


### PR DESCRIPTION
## What

- Removed a duplicate sentence found in the RNS user guide. The sentence 'One of the ways to operate with the service is through the application known as the manager' was repeated twice.

## Why

- The removal of the repeated sentence enhances the readability and clarity of the documentation. Duplicate information can be confusing or misleading for users, and maintaining concise and accurate documentation is essential for user understanding and experience.

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
