### PR TITLE
Update RIF whitepaper

### DIFF
--- a/content/rsk-devportal/grants/follow-up/index.html
+++ b/content/rsk-devportal/grants/follow-up/index.html
@@ -94,7 +94,7 @@
                         <li class="negbottom">Whitepapers</li>
                         <li class="sub-item-footer"><a href="https://www.rsk.co/Whitepapers/RSK_White_Paper-ORIGINAL.pdf" rel="nofollow noopener noreferrer" target="_blank">Original</a></li>
                         <li class="sub-item-footer"><a href="https://www.rsk.co/Whitepapers/RSK-White-Paper-Updated.pdf" rel="nofollow noopener noreferrer" target="_blank">Updated</a></li>
-                        <li class="sub-item-footer"><a href="https://docs.rifos.org/rif-whitepaper-en.pdf" rel="nofollow noopener noreferrer" target="_blank">RIF</a></li>
+                        <li class="sub-item-footer"><a href="https://rif.technology/static/add903ce229a6f45a606cd78b028cf9e/RIF-whitepaper-V2.pdf" rel="nofollow noopener noreferrer" target="_blank">RIF</a></li>
                         <li><a href="https://fund.rsk.co" rel="nofollow noopener noreferrer" target="_blank">Ecosystem Fund</a></li>
                         <li><a href="https://studio.rsk.co" rel="nofollow noopener noreferrer" target="_blank">Innovation Studio</a></li>
                         <li><a href="https://mining.rsk.co" rel="nofollow noopener noreferrer" target="_blank">Merged Mining</a></li>

--- a/content/rsk-devportal/rif/index.md
+++ b/content/rsk-devportal/rif/index.md
@@ -32,9 +32,9 @@ RIF Gateways develops tools and technologies to allow decentralized applications
 
 Learn more about [RIF Gateways](../rif/gateways/)
 
-#### RIF OS White Paper
+#### RIF White Paper
 
-To understand the general vision behind RIF OS, read the [RIF OS White Paper](https://docs.rifos.org/rif-whitepaper-en.pdf).
+To understand the general vision behind RIF OS, read the [RIF White Paper](https://rif.technology/static/add903ce229a6f45a606cd78b028cf9e/RIF-whitepaper-V2.pdf).
 
 #### RIF FAQ
 


### PR DESCRIPTION
## What

Updated the RIF overview page to:
- Use RIF instead of RIF
- Point to the new rebranded whitepaper

## Why

- The overview page currently refers to RIF as RIF OS and links to the [old whitepaper](https://docs.rifos.org/rif-whitepaper-en.pdf) instead of the [new rebranded one](https://rif.technology/static/add903ce229a6f45a606cd78b028cf9e/RIF-whitepaper-V2.pdf).

## Refs

- https://rsklabs.atlassian.net/browse/D1-781
