### PR TITLE
Docs: Removed Old RIF Products no longer supported from left navigation

### DIFF
--- a/content/rsk-devportal/rif/gateways/index.md
+++ b/content/rsk-devportal/rif/gateways/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 800
+# menu_order: 800
 section_title: Gateways
 menu_title: About
 layout: rsk

--- a/content/rsk-devportal/rif/identity/index.md
+++ b/content/rsk-devportal/rif/identity/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 200
+# menu_order: 200
 section_title: Identity
 menu_title: Intro
 title: Intro

--- a/content/rsk-devportal/rif/marketplace/index.md
+++ b/content/rsk-devportal/rif/marketplace/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 700
+# menu_order: 700
 section_title: Marketplace
 menu_title: About
 layout: rsk

--- a/content/rsk-devportal/rif/multisig/index.md
+++ b/content/rsk-devportal/rif/multisig/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 1000
+# menu_order: 1000
 section_title: Multisig
 menu_title: Overview
 layout: rsk

--- a/content/rsk-devportal/rif/scheduler/index.md
+++ b/content/rsk-devportal/rif/scheduler/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 900
+# menu_order: 900
 section_title: Scheduler
 menu_title: Getting Started
 layout: rsk

--- a/content/rsk-devportal/rif/storage/index.md
+++ b/content/rsk-devportal/rif/storage/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 600
+# menu_order: 600
 section_title: Storage
 menu_title: About RIF Storage
 layout: rsk


### PR DESCRIPTION
## What

- Removed Old RIF Products from left navigation

* Gateways
* Marketplace
* Multisig
* Scheduler
* Identity
* Storage

## Why
- old and not actively maintained

## Refs

- [Task](https://rsklabs.atlassian.net/browse/D1-775?atlOrigin=eyJpIjoiNTljYzJiNmRkYTg3NGI5MzkwNjc5OTgzODg0OGE0YzQiLCJwIjoiaiJ9)
