### PR TITLE
Replace slack link with discord

### DIFF
--- a/content/rsk-devportal/grants/follow-up/index.html
+++ b/content/rsk-devportal/grants/follow-up/index.html
@@ -129,7 +129,7 @@
                 <a href="https://twitter.com/rsksmart" rel="nofollow noopener noreferrer" target="_blank" class="twitter"><i class="fab fa-twitter"></i></a>
                 <a href="https://www.youtube.com/rsksmart" rel="nofollow noopener noreferrer" target="_blank" class="facebook"><i class="fab fa-youtube"></i></a>
                 <a href="https://www.facebook.com/RSKsmart/" rel="nofollow noopener noreferrer" target="_blank" class="linkedin"><i class="fab fa-facebook"></i></a>
-                <a href="/slack/" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-slack"></i></a>
+                <a href="/discord/" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-slack"></i></a>
                 <a href="https://www.reddit.com/r/rootstock/" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-reddit"></i></a>
                 <a href="https://t.me/rskofficialcommunity" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-telegram"></i></a>
                 <a href="https://medium.com/@RSKNews" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-medium"></i></a>


### PR DESCRIPTION
## What

- Replaced old slack links with discord link

## Why

- The Rootstock Open Slack was sunset on 31st of October 2023

## Refs

- https://rsklabs.atlassian.net/browse/D1-750
