### PR TITLE
Update old facebook links

### DIFF
--- a/content/rsk-devportal/grants/follow-up/index.html
+++ b/content/rsk-devportal/grants/follow-up/index.html
@@ -128,7 +128,7 @@
             <div class="social-links" >
                 <a href="https://twitter.com/rsksmart" rel="nofollow noopener noreferrer" target="_blank" class="twitter"><i class="fab fa-twitter"></i></a>
                 <a href="https://www.youtube.com/rsksmart" rel="nofollow noopener noreferrer" target="_blank" class="facebook"><i class="fab fa-youtube"></i></a>
-                <a href="https://www.facebook.com/RSKsmart/" rel="nofollow noopener noreferrer" target="_blank" class="linkedin"><i class="fab fa-facebook"></i></a>
+                <a href="https://www.facebook.com/rootstock.io/" rel="nofollow noopener noreferrer" target="_blank" class="linkedin"><i class="fab fa-facebook"></i></a>
                 <a href="/slack/" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-slack"></i></a>
                 <a href="https://www.reddit.com/r/rootstock/" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-reddit"></i></a>
                 <a href="https://t.me/rskofficialcommunity" rel="nofollow noopener noreferrer" target="_blank" class="instagram"><i class="fab fa-telegram"></i></a>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -152,7 +152,7 @@ const Footer = () => {
                   </defs>
                 </svg>
               </a>
-              <a className="me-5 zg-social-icon" aria-label="Facebook" href="https://www.facebook.com/RSKsmart/"
+              <a className="me-5 zg-social-icon" aria-label="Facebook" href="https://www.facebook.com/rootstock.io/"
                  target="_blank"
                  rel="noopener noreferrer">
                 <svg width="32" height="32" viewBox="0 0 32 32" fill="none">


### PR DESCRIPTION
## What

- Replace old facebook link - https://www.facebook.com/RSKsmart/ with new one - https://www.facebook.com/rootstock.io/

## Why

- The old link is outdated

## Refs

- https://rsklabs.atlassian.net/browse/D1-771
