### PR TITLE
Docs: General maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Note: This is useful as a last resort when your local project seems to have [iss
 To run tests that check whether there are any errors in the site:
 
 ```bash
-??
+TODO
 ```
 
 This runs tests that check whether there are any errors in the site.

--- a/content/rsk-devportal/contribute/bug-bounty-program.md
+++ b/content/rsk-devportal/contribute/bug-bounty-program.md
@@ -3,7 +3,7 @@ menu_order: 200
 menu_title: Bug Bounty Program
 layout: rsk
 title: Bug Bounty Program
-tags: rsk, rif, bounty, security
+tags: rsk, rif, bounty, security, rootstock
 ---
 
 IOVLabs has created this bug bounty program to reward security researchers that dedicate time and effort to improve the IOVLabs platforms.

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -10,7 +10,7 @@ The RSK stack is open-source, if you are interested in colaborate, follow these 
 
 - [RSKj (node)](/rsk/node/contribute)
 - [RNS](https://github.com/rnsdomains/rnsips)
-- [Lumino node](/rif/lumino/node/contribute)
-- [RSK Github](https://github.com/rsksmart)
+- [RIF Relay](/rif/relay/)
+- [Rootstock Github](https://github.com/rsksmart)
 
-Check out the [RSK bug bounty program](/contribute/bug-bounty-program).
+Check out the [Rootstock bug bounty program](/contribute/bug-bounty-program).

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -6,7 +6,7 @@ menu_title: Contribute
 section_title: Contribute
 ---
 
-The RSK stack is open-source, if you are interested in colaborate, follow these links:
+The Rootstock stack is open-source, if you are interested in colaborate, follow these links:
 
 - [RSKj (node)](/rsk/node/contribute)
 - [RNS](https://github.com/rnsdomains/rnsips)

--- a/content/rsk-devportal/courses/blockchain-developer.md
+++ b/content/rsk-devportal/courses/blockchain-developer.md
@@ -17,9 +17,10 @@ In this course, you will learn how to write, test, compile, deploy, secure, and 
 
 ... and it is completely free!
 
-<a href="https://rsk.thinkific.com/courses/blockchain-developer/" target="_blank">
-  <button class="orange-button">Become a Blockchain Developer</button>
-</a>
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="https://rsk.thinkific.com/courses/blockchain-developer/">Become a Blockchain Developer</a>
+</div>
 
 ## Who should take the course?
 

--- a/content/rsk-devportal/courses/user-course.md
+++ b/content/rsk-devportal/courses/user-course.md
@@ -17,9 +17,10 @@ This course is for a technical user, but does not require or involve any program
 
 ... and it is completely free!
 
-<a href="https://rsk.thinkific.com/courses/blockchain-user/" target="_blank">
-  <button class="orange-button">Become a Rootstock User</button>
-</a>
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="https://rsk.thinkific.com/courses/blockchain-user/">Become a Rootstock User</a>
+</div>
 
 ## Who should take the course?
 

--- a/content/rsk-devportal/kb/truffle-rsk-starter-box.md
+++ b/content/rsk-devportal/kb/truffle-rsk-starter-box.md
@@ -1,8 +1,8 @@
 ---
 menu_order: 3400
-menu_title: Truffle Boxes with RSK
+menu_title: Truffle RSK Starter Box
 layout: rsk
-title: Using Truffle box rsk-starter-box
+title: Using Truffle rsk-starter-box
 tags: tutorial, rsk, truffle, truffle-box
 description: "How to use the Truffle box rsk-starter-box, which comes with everything you need to start using Truffle on RSK networks. It includes network configurations for Mainnet, Testnet and the SimpleStorage contract as an example to deploy."
 render_features: "custom-terminals"

--- a/content/rsk-devportal/rif/index.md
+++ b/content/rsk-devportal/rif/index.md
@@ -2,9 +2,9 @@
 layout: rsk
 menu_order: 3
 section_title: RIF
-menu_title: About RSK Infrastructure Framework
-title: RSK Infrastructure Framework
-tags: rif, rif-storage, rif-lumino, rns, rif-identity, DID, ipfs, swarm, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
+menu_title: About RIF
+title: Rootstock Infrastructure Framework
+tags: rif, rootstock, rif-rollup, rif-relay, rns, rif-wallet, storage, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
 ## RIF Services
@@ -19,18 +19,59 @@ RIF OS Protocols enable broad interoperability and faster time-to-deployment, an
   <video style="width: 100%" controls src="https://cdn.rifos.org/home_video.mp4"></video>
 </div>
 
+#### RIF Wallet
+
+RIF Wallet provides a full stack library of functionalities that allow you to easily integrate crypto lending, saving and paying services into your existing product or launch your own smart wallet.
+
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="../rif/">Coming Soon</a>
+</div>
 
 #### RIF Name Service
 
 RNS is a decentralized service that allows users to have a readable domain or alias. It can be used to identify other personal resources, such as payment or communication addresses.
 
-Learn more about [RIF Name Service](../rif/rns/)
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="../rif/rns/">Create a domain or alias</a>
+</div>
 
-### RIF Gateways
+#### RIF Rollup
 
-RIF Gateways develops tools and technologies to allow decentralized applications to seamlessly connect to the external world. 
+RIF Rollup is a trustless protocol for fast and scalable low-cost payments on Rootstock powered by zkRollup Technology. Its current functionality and scope includes low gas transfers of RBTC and ERC20 tokens on the Rootstock network.
 
-Learn more about [RIF Gateways](../rif/gateways/)
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="../rif/rollup">Learn more about RIF Rollup</a>
+</div>
+
+#### rLogin
+
+Learn how to integrate rLogin into your app and allow users to choose their favourite wallets to log in. With a single tool, you will get connected to their wallet using an API compatible with Metamask and other wallets.
+
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="../rif/rlogin/">Get started</a>
+</div>
+
+#### RIF Flyover
+
+The Flyover protocol performs fast peg-ins. It provides a new feature to transfer BTC from Bitcoin directly to a smart contract or EOA in RSK faster than the regular [peg in](../rsk/architecture/powpeg/) protocol.
+
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="../guides/flyover/">Learn more about RIF Flyover</a>
+</div>
+
+#### RIF Relay
+
+RIF Relay is a secure sponsored transaction system that enables users to pay the transaction fees using ERC-20 tokens. This enables end users to transact entirely using one asset instead of having to manage a separate asset for gas.
+
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="../rif/relay/">Integrate RIF Relay</a>
+</div>
 
 #### RIF White Paper
 

--- a/content/rsk-devportal/the-stack/index.md
+++ b/content/rsk-devportal/the-stack/index.md
@@ -14,15 +14,15 @@ menu_order: 1
                 <div class="col"><span><a href="/tutorials/tokens/create-a-token">Asset Tokenization</a></span></div>
                 <div class="col"><span>Stablecoins</span></div>
                 <div class="col"><span>Payments</span></div>
-                <div class="col"><span>Margin Trading</span></div>
-                <div class="col"><span>Lending and borrowing</span></div>
-                <div class="col"><span>Derivatives</span></div>
-                <div class="col"><span>Insurance</span></div>
-                <div class="col"><span>Escrow</span></div>
-                <div class="col"><span>Prediction Markets</span></div>
+                <div class="col"><span>Leverage and Trading</span></div>
+                <div class="col"><span>Lending</span></div>
+                <div class="col"><span>Asset swaps</span></div>
+                <div class="col"><span>Bridges</span></div>
                 <div class="col"><span>Marketplaces</span></div>
-                <div class="col"><span>Scoring</span></div>
-                <div class="col"><span>Liquidity protocols</span></div>
+                <div class="col"><span>On/Off Ramps</span></div>
+                <div class="col"><span>Data and Analytics</span></div>
+                <div class="col"><span>Staking</span></div>
+                <div class="col"><span>Oracles</span></div>
             </div>
         </div>
     <div class="row has-unique-col rif_blue_text">
@@ -30,19 +30,20 @@ menu_order: 1
     </div>
     <div class="row has-unique-col">
         <div class="col">
-            <div class="row rotate">RIF Marketplace</div>
+            <div class="row rotate">RIF Economy</div>
             <div class="row rif_blue dapps">
-                <div class="col"><span><a href="/rif/rns/">RIF Directory</a></span></div>
-                <div class="col"><span><a href="/rif/lumino/">RIF Payments</a></span></div>
-                <div class="col"><span><a href="/rif/storage/">RIF Storage</a></span></div>
-                <div class="col"><span>RIF Comms</span></div>
-                <div class="col"><span>RIF Gateways</span></div>
-                <div class="col grey"><span>Your sharing economy</span></div>
-            </div>
+                <div class="col"><span><a href="../rif/token">RIF Token</a></span></div>
+                <div class="col"><span><a href="../rif/rns/">RNS</a></span></div>
+                <div class="col"><span><a href="../rif/relay/">Relay</a></span></div>
+                <div class="col"><span><a href="../rif/rollup/">Rollup</a></span></div>
+                <div class="col"><span>Wallet</span></div>
+                <div class="col"><span>Flyover</span></div>
+        </div>
+    </div>
         </div>
     </div>
     <div class="row has-unique-col rsk_green">
-        <div class="col"><span><a href="/rsk/">rsk smart contracts</a></span></div>
+        <div class="col"><span><a href="/rsk/">Rootstock Smart Contracts</a></span></div>
     </div>
     <div class="row has-unique-col bitcoin">
         <div class="col"><span><a href="https://bitcoin.org/en/development">Bitcoin: Store of Value</a></span></div>

--- a/src/components/before-content/component-one/index.tsx
+++ b/src/components/before-content/component-one/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 const ComponentOne = () => {
     return(
-        <a href="http://rootstock.io/discord" target="_blank" rel="noopener noreferrer"> 📢 Join the Rootstock Global Discord Community to
-        get the latest updates from the Rootstock Ecosystem!
+        <a href="http://rootstock.io/discord" target="_blank" rel="noopener noreferrer">Join the Rootstock Global Discord Community to
+        get the latest updates from the Ecosystem!
         </a>
     )
 }

--- a/src/components/before-content/index.tsx
+++ b/src/components/before-content/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import Marquee from "react-fast-marquee";
+// import Marquee from "react-fast-marquee";
 import classnames from "classnames";
-// import ComponentOne from "./component-one";
-// import ComponentTwo from "./component-two";
-import ComponentThree from "./component-three";
+import ComponentOne from "./component-one";
 
 interface Props {
   className?: string;
@@ -11,14 +9,9 @@ interface Props {
 
 const BeforeContent = ({ className }: Props) => {
   return (
-    <Marquee className={classnames('before-content', className)} direction="left" pauseOnHover>      
-      {/* &nbsp;     
+    <div className={classnames('before-content', className)}>      
       <ComponentOne />
-      &nbsp;
-      <ComponentTwo />
-      &nbsp; */}
-      <ComponentThree />
-    </Marquee>
+    </div>
   );
 }
 

--- a/src/components/header/menu.tsx
+++ b/src/components/header/menu.tsx
@@ -59,8 +59,8 @@ const links: NavLink[] = [
     label: 'Learn',
     children: [
       {
-        label: 'Webinars',
-        link: '/webinars/'
+        label: 'Courses',
+        link: '/courses/'
       }
     ]
   },
@@ -78,7 +78,7 @@ const links: NavLink[] = [
       },
       {
         label: 'RIF Name Service',
-        link: 'https://www.rifos.org/nameservice/index',
+        link: 'https://rif.technology/solutions/#rns',
         external: true
       },
       {

--- a/src/pages/newsletter.tsx
+++ b/src/pages/newsletter.tsx
@@ -150,4 +150,4 @@ const NewsletterPage = () => {
 
 export default NewsletterPage;
 
-export const Head: HeadFC = () => <title>RSK Developers Portal - Newsletter</title>
+export const Head: HeadFC = () => <title>Rootstock Developers Portal - Newsletter</title>

--- a/src/templates/docs/index.tsx
+++ b/src/templates/docs/index.tsx
@@ -79,7 +79,7 @@ export const Head: HeadFC = ({pageContext}) => {
   return (
     <>
       {/*@ts-ignore*/}
-      <Seo title={`RSK Devportal - ${pageContext.title}`}>
+      <Seo title={`Rootstock Devportal - ${pageContext.title}`}>
         <link href="/assets/css/owl.carousel.min.css" rel="stylesheet"/>
         <link href="/assets/css/owl.theme.default.min.css" rel="stylesheet"/>
         <link href="/assets/css/code.css" rel="stylesheet"/>


### PR DESCRIPTION
## What

- Updated the stack page
- Updated buttons in Courses section
- Updated banner to stop marquee
- Added RIF Products to RIF Landing
- Renamed repeated Truffle box titles
- Changed Learn > Webinar to link to `/courses` in header
- Changed Lumino to Relay in contribute page
- Updated RSK to Rootstock in Newsletter and Title

## Why

- Docs maintenance

## Refs

- [Task](https://rsklabs.atlassian.net/browse/D1-690?atlOrigin=eyJpIjoiNGJkZTVlYjZkMzIwNGYyMjgwNGE0YWE2YjIyOGQ0ZDciLCJwIjoiaiJ9)
