### PR TITLE
fix Broken link in the devportal

### DIFF
--- a/content/rsk-devportal/guides/two-way-peg-app/pegin/index.md
+++ b/content/rsk-devportal/guides/two-way-peg-app/pegin/index.md
@@ -32,7 +32,7 @@ We will do the following:
 ## Resources
 * 2 way peg app frontend [repo](https://github.com/rsksmart/2wp-app)
 * 2 way peg app backend [repo](https://github.com/rsksmart/2wp-api)
-* How to get [RBTC using Rootstock’s built in Powpeg](https://developers.rootstock.io/guides/get-crypto-on-rsk/powpeg-btc-rbtc/)
+* How to get [RBTC using Rootstock’s built in Powpeg](https://dev.rootstock.io/guides/get-crypto-on-rsk/powpeg-btc-rbtc/)
 * [Rootstock Testnet Faucet](https://faucet.rootstock.io/)
 * [Get RBTC using Exchanges](https://developers.rootstock.io/guides/get-crypto-on-rsk/rbtc-exchanges/)
 * [Design architecture](/guides/two-way-peg-app/advanced-operations/design-architecture/)

--- a/content/rsk-devportal/guides/two-way-peg-app/pegin/index.md
+++ b/content/rsk-devportal/guides/two-way-peg-app/pegin/index.md
@@ -32,7 +32,7 @@ We will do the following:
 ## Resources
 * 2 way peg app frontend [repo](https://github.com/rsksmart/2wp-app)
 * 2 way peg app backend [repo](https://github.com/rsksmart/2wp-api)
-* How to get [RBTC using Rootstock’s built in Powpeg](https://dev.rootstock.io/guides/get-crypto-on-rsk/powpeg-btc-rbtc/)
+* How to get [RBTC using Rootstock’s built in Powpeg](/guides/get-crypto-on-rsk/powpeg-btc-rbtc/)
 * [Rootstock Testnet Faucet](https://faucet.rootstock.io/)
-* [Get RBTC using Exchanges](https://developers.rootstock.io/guides/get-crypto-on-rsk/rbtc-exchanges/)
+* [Get RBTC using Exchanges](/guides/get-crypto-on-rsk/rbtc-exchanges/)
 * [Design architecture](/guides/two-way-peg-app/advanced-operations/design-architecture/)


### PR DESCRIPTION
## What

- Fix broken links in 2 way peg app on the dev portal

## Why

- The link is broken and inconsistent. It was redirecting to https://developers.rootstock.io/guides/get-crypto-on-rsk/powpeg-btc-rbtc/ rather than https://dev.rootstock.io/guides/get-crypto-on-rsk/powpeg-btc-rbtc/
