### PR TITLE
Update json-rpc architecture link

### DIFF
--- a/content/rsk-devportal/rsk/node/architecture/index.md
+++ b/content/rsk-devportal/rsk/node/architecture/index.md
@@ -8,7 +8,7 @@ permalink: /rsk/node/architecture/
 ---
 
 <ul>
-  <li><a href="/rsk/node/architecture/json-rpc/">JSON-RPC</a></li>
+  <li><a href="https://dev.rootstock.io/rsk/node/architecture/json-rpc/">JSON-RPC</a></li>
   <li><a href="https://web3js.readthedocs.io/en/v1.2.0/" target="_blank">Web3</a></li>
   <li><a href="https://blog.rsk.co/noticia/towards-higher-onchain-scalability-with-the-unitrie/" target="_blank">Storage</a></li>
 </ul>


### PR DESCRIPTION
This link obviously exists, but clicking it currently leads to ERR_TOO_MANY_REDIRECTS. This might not be the right solution but I think it fixes the link

Link in question is here: https://dev.rootstock.io/rsk/node/architecture/