### PR TITLE
Docs: Fix menu order and update before content

### DIFF
--- a/content/rsk-devportal/guides/starter-kits/dapp-automation-cucumber.md
+++ b/content/rsk-devportal/guides/starter-kits/dapp-automation-cucumber.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 900
+menu_order: 1005
 menu_title: DApp Automation with Cucumber
 title: 'DApp Automation with Cucumber & Playwright'
 description: 'Testing decentralized applications (DApps) is crucial for delivering a smooth user experience and ensuring the reliability of decentralized systems. Thorough testing of the frontend identifies and addresses usability issues, creating a user-friendly interface. Cucumber and Playwright form a dynamic duo in automated testing, blending behavior-driven development (BDD) and powerful browser automation capabilitie.'

--- a/content/rsk-devportal/guides/starter-kits/hackathon-starter.md
+++ b/content/rsk-devportal/guides/starter-kits/hackathon-starter.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 1100
+menu_order: 1002
 menu_title: Hackathon Dev Starter Kit
 layout: rsk
 title: "Rootstock Hackathon Dev Starter"

--- a/content/rsk-devportal/guides/starter-kits/index.md
+++ b/content/rsk-devportal/guides/starter-kits/index.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 1000
+menu_order: 1001
 menu_title: Starter Kits
 layout: rsk
 title: "Starter Kits for easy Rootstock Development"

--- a/content/rsk-devportal/guides/starter-kits/javascript-testing.md
+++ b/content/rsk-devportal/guides/starter-kits/javascript-testing.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 1200
+menu_order: 1003
 menu_title: Javascript Testing Kits
 layout: rsk
 title: "Rootstock Workshop: Javascript Testing"

--- a/content/rsk-devportal/guides/starter-kits/smart-contract-testing.md
+++ b/content/rsk-devportal/guides/starter-kits/smart-contract-testing.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 1300
+menu_order: 1004
 menu_title: Smart Contract Testing with Truffle
 layout: rsk
 title: "Rootstock Workshop: Smart Contract Testing using Truffle"

--- a/content/rsk-devportal/tools/rpc-api.md
+++ b/content/rsk-devportal/tools/rpc-api.md
@@ -1,5 +1,5 @@
 ---
-menu_order: 500
+menu_order: 450
 menu_title: Rootstock RPC API
 section_title: RPC API
 layout: rsk

--- a/src/components/before-content/component-three/index.tsx
+++ b/src/components/before-content/component-three/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 const ComponentThree = () => {
     return(
-        <a href="https://blog.rootstock.io/noticia/merged-mining-insights-report-q1-2024/" target="_blank" rel="noopener noreferrer"> Rootstock x Bitcoin: Merged Mining Insights Report | Q4 2024. 
-        Read on for insights on the top mining pools, average hashrate and more.
+        <a href="https://taikai.network/en/rootstock/hackathons/bitcoin-rootstock-hackathon/overview" target="_blank" rel="noopener noreferrer"> Bitcoin Meets Solidity Hackathon now open for registration.
+        This hackathon brings together developers & blockchain enthusiasts to build on top of #Bitcoin technology using Rootstock.
       </a>
     )
 }


### PR DESCRIPTION
## What

- Fix Menu order with missing pages
- Update before content to hackathon announcement

## Why

- Docs maintenance (May, 2024)

## Refs

- [Task](https://rsklabs.atlassian.net/browse/DTW-124?atlOrigin=eyJpIjoiNGI4MWE0ZWVmMWRlNGI4ZTlhYzM5ZTdjOTM0NTYyMDYiLCJwIjoiaiJ9)
