### PR TITLE
Update JSON RPC eth_call description

### DIFF
--- a/content/rsk-devportal/rsk/node/architecture/json-rpc/json-rpc-methods.md
+++ b/content/rsk-devportal/rsk/node/architecture/json-rpc/json-rpc-methods.md
@@ -993,7 +993,7 @@ Executes a new message call immediately without creating a transaction on the bl
   - `gas`: `QUANTITY`  - (optional) Integer of the gas provided for the transaction execution. eth_call consumes zero gas, but this parameter may be needed by some executions.
   - `gasPrice`: `QUANTITY`  - (optional) Integer of the gasPrice used for each paid gas
   - `value`: `QUANTITY`  - (optional) Integer of the value sent with this transaction
-  - `data`: `DATA`  - (optional) Hash of the method signature and encoded parameters. For details see [Ethereum Contract ABI in the Solidity documentation](https://solidity.readthedocs.io/en/latest/abi-spec.html)
+  - `data|input`: `DATA`  - (optional) Hash of the method signature and encoded parameters. For details see [Ethereum Contract ABI in the Solidity documentation](https://solidity.readthedocs.io/en/latest/abi-spec.html)
 2. `QUANTITY|TAG` - integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block)
 
 ##### Example Parameters
@@ -1018,6 +1018,17 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_call","params":[{see above}]
   "id":1,
   "jsonrpc": "2.0",
   "result": "0x"
+}
+
+// In case of REVERT error
+{
+   "jsonrpc":"2.0",
+   "id":1,
+   "error":{
+      "code":-32015,
+      "message":"VM Exception while processing transaction: revert reason",
+      "data":"0x08c379a..."
+   }
 }
 ```
 


### PR DESCRIPTION
## What

- Added `input` as alternative name for the `data` argument.
- Added and example of the request response in case of a REVERT error.

## Why

- Aligning Dev Portal documentation with changes introduced in 6.2.0 release.

## Refs

- [CORE-5654](https://rsklabs.atlassian.net/browse/CORE-5654)
