### PR TITLE
Docs: Add content contributor landing page and update before-content

### DIFF
--- a/content/rsk-devportal/contribute/bug-bounty-program.md
+++ b/content/rsk-devportal/contribute/bug-bounty-program.md
@@ -1,14 +1,35 @@
 ---
 menu_order: 200
 menu_title: Bug Bounty Program
+section_title: Contribute to the Bug Bounty Program
 layout: rsk
-title: Bug Bounty Program
+title: Contribute to RootstockLabs platforms security
 tags: rsk, rif, bounty, security, rootstock
 ---
 
-RootstockLabs has created this bug bounty program to reward security researchers that dedicate time and effort to improve the RootstockLabs platforms.
+RootstockLabs has created the bug bounty program to reward researchers that submit valid vulnerabilities to improve the RootstockLabs platforms security.
 
 <div class="btn-container">
   <span></span>
     <a class="green" href="https://hackerone.com/rootstocklabs">Visit the Bug Bounty Program Page on Hackerone</a>
 </div>
+
+### Service Level Agreement (SLA)
+
+RootstockLabs aims to meet the following SLAs for hackers participating in our program:
+
+* Time to first response (from report submit) - 5 business days
+* Time to triage (from report submit) - 7 business days
+* Time to bounty (from triage) - 15 business days
+
+We aim to keep you informed about the progress throughout the process.
+
+### Disclosure Policy
+
+* Follow HackerOne's [disclosure guidelines](https://www.hackerone.com/disclosure-guidelines).
+* Public disclosure of a vulnerability makes it ineligible for a bounty. If the user reports the vulnerability to other security teams (e.g. Ethereum or ETC) but reports to RootstockLabs with considerable delay, then RootstockLabs may reduce or cancel the bounty.
+
+### Scope and Rules
+
+Visit the [Scope Section on Hackerone](https://hackerone.com/rootstocklabs/policy_scopes) to view the scope / out of scope vulnerability, and the program rules.
+

--- a/content/rsk-devportal/contribute/bug-bounty-program.md
+++ b/content/rsk-devportal/contribute/bug-bounty-program.md
@@ -8,4 +8,7 @@ tags: rsk, rif, bounty, security, rootstock
 
 RootstockLabs has created this bug bounty program to reward security researchers that dedicate time and effort to improve the RootstockLabs platforms.
 
-<a href="https://hackerone.com/rootstocklabs" target="_blank" class="green-button">Bug Bounty Program</a>
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="https://hackerone.com/rootstocklabs">Visit the Bug Bounty Program Page on Hackerone</a>
+</div>

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -8,15 +8,17 @@ description: "An overview of different ways you can contribute to Rootstock."
 tags: rootstock, workshop, pre-requisites
 ---
 
-Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, and solving real-world problems, and eager to contribute to the future of decentralized finance? Join the [Rootstock Ecosystem Discord](https://rootstock.io/discord) and start making contributions to the Rootstock Platform!
+Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, bounty-hunting, solving real-world problems, and eager to contribute to the future of Bitcoin and Decentralized Finance? Join the [Rootstock Discord Community](https://rootstock.io/discord) and start making contributions to the Rootstock Platform!
 
 ## Who is it for?
-Whether you're a seasoned developer, a creative writer, a bug bounty hunter, or simply enthusiastic about blockchain, our program welcomes contributors from all backgrounds. If you have a skill or an idea to share, we want to hear from you.
+
+Whether you're a seasoned developer, creative writer, researcher, bug bounty hunter, or simply enthusiastic about blockchain, the program welcomes contributors from all backgrounds.
 
 ## Rewards and Recognition
+
 From writing contests to bug bounties and open-source projects, there are various ways to participate and earn valuable incentives. Not only that, but you'll also get a chance to build your portfolio by writing and solving problems with real problems and use-cases in the Rootstock ecosystem.
 
-Explore the diverse ways you can contribute:
+Explore the various ways you can contribute to Rootstock:
 
 <div class="features-list">
     <ul id="card-list" class="row">

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -8,7 +8,7 @@ description: "An overview of different ways you can contribute to Rootstock."
 tags: rootstock, workshop, pre-requisites
 ---
 
-Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, bounty-hunting, solving real-world problems, and eager to contribute to the future of Bitcoin and Decentralized Finance? Join the [Rootstock Discord Community](https://rootstock.io/discord) and start making contributions to the Rootstock Platform!
+Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, bounty hunting, solving real-world problems, and eager to contribute to the future of Bitcoin and Decentralized Finance? Join the [Rootstock Discord Community](https://rootstock.io/discord) and start making contributions to the Rootstock Platform!
 
 ## Who is it for?
 

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -25,7 +25,7 @@ Explore the diverse ways you can contribute:
         <div class="content two-line-title-content"><a href="https://hackerone.com/rootstocklabs">
             <div class="content-container">
             <div class="card-title"><h2 class="zg-text-bg bg-pink">Bug Bounty Program</h2><span class="zg-label ml-1 bg-pink">01</span></div>
-                <p class="card-desc">RootstockLabs has created this bug bounty program to reward security researchers that dedicate time and effort to improve the RootstockLabs platforms.</p>
+                <p class="card-desc">RootstockLabs has created the bug bounty program to reward researchers that submit valid vulnerabilities to improve the RootstockLabs platforms security.</p>
             </div>
             </a><div class="btn-container"><a href="https://hackerone.com/rootstocklabs">
                 </a><a class="green" href="https://hackerone.com/rootstocklabs">Rootstock Bug Bounty Program</a>
@@ -38,7 +38,7 @@ Explore the diverse ways you can contribute:
         <div class="content"><a href="https://github.com/rsksmart">
             <div class="content-container">
                <div class="card-title"><h2 class="zg-text-bg">Open Source Code</h2><span class="zg-label ml-1">02</span></div> 
-                <p class="card-desc">Contribute Code to Open Source Repos on Rootstock</p>
+                <p class="card-desc">Contribute to Rootstock's Open Source Code Repos</p>
             </div>
             </a><div class="btn-container "><a href="https://github.com/rsksmart">
                 </a><a class="green" href="https://github.com/rsksmart">Star on GitHub</a>
@@ -51,7 +51,7 @@ Explore the diverse ways you can contribute:
             <div class="content"><a href="/contribute/writing-contests/">
             <div class="content-container">
               <div class="card-title"><h2 class="zg-text-bg bg-yellow">Bitcoin Writing Contest</h2><span class="zg-label ml-1 bg-yellow">03</span></div> 
-                <p class="card-desc">Contribute articles, tutorials and guides on Rootstock.</p>
+                <p class="card-desc">Contribute articles, tutorials and guides about Rootstock, Bitcoin, etc.</p>
             </div>
             </a><div class="btn-container"><a href="/contribute/writing-contests/">
                 </a><a class="green" href="https://www.contests.hackernoon.com/bitcoin-writing-contest">Enter the Contest</a>

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -1,16 +1,63 @@
 ---
 layout: rsk
-title: Contribute
+title: Contribute to Rootstock
 menu_order: 11
-menu_title: Contribute
-section_title: Contribute
+menu_title: Overview
+section_title: Contribute to Rootstock
+description: "An overview of different ways you can contribute to Rootstock."
+tags: rootstock, workshop, pre-requisites
 ---
 
-The Rootstock stack is open-source, if you are interested in colaborate, follow these links:
+Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, and solving real-world problems, and eager to contribute to the future of decentralized finance? Join the [Rootstock Ecosystem Discord](https://rootstock.io/discord) and start making contributions to the Rootstock Platform!
 
-- [RSKj (node)](/rsk/node/contribute)
-- [RNS](https://github.com/rnsdomains/rnsips)
-- [RIF Relay](/rif/relay/)
-- [Rootstock Github](https://github.com/rsksmart)
+## Who is it for?
+Whether you're a seasoned developer, a creative writer, a bug bounty hunter, or simply enthusiastic about blockchain, our program welcomes contributors from all backgrounds. If you have a skill or an idea to share, we want to hear from you.
 
-Check out the [Rootstock bug bounty program](/contribute/bug-bounty-program).
+## Rewards and Recognition
+From writing contests to bug bounties and open-source projects, there are various ways to participate and earn valuable incentives. Not only that, but you'll also get a chance to build your portfolio by writing and solving problems with real problems and use-cases in the Rootstock ecosystem.
+
+Explore the diverse ways you can contribute:
+
+<div class="features-list">
+    <ul id="card-list" class="row">
+    <li class="col-xl-6 col-md-6">
+        <div class="feature-card">
+        <div class="content two-line-title-content"><a href="https://hackerone.com/rootstocklabs">
+            <div class="content-container">
+            <div class="card-title"><h2 class="zg-text-bg bg-pink">Bug Bounty Program</h2><span class="zg-label ml-1 bg-pink">01</span></div>
+                <p class="card-desc">RootstockLabs has created this bug bounty program to reward security researchers that dedicate time and effort to improve the RootstockLabs platforms.</p>
+            </div>
+            </a><div class="btn-container"><a href="https://hackerone.com/rootstocklabs">
+                </a><a class="green" href="https://hackerone.com/rootstocklabs">Rootstock Bug Bounty Program</a>
+            </div>
+            </div>
+        </div>
+        </li>
+    <li class="col-xl-6 col-md-6">
+        <div class="feature-card">
+        <div class="content"><a href="https://github.com/rsksmart">
+            <div class="content-container">
+               <div class="card-title"><h2 class="zg-text-bg">Open Source Code</h2><span class="zg-label ml-1">02</span></div> 
+                <p class="card-desc">Contribute Code to Open Source Repos on Rootstock</p>
+            </div>
+            </a><div class="btn-container "><a href="https://github.com/rsksmart">
+                </a><a class="green" href="https://github.com/rsksmart">Star on GitHub</a>
+            </div>
+            </div>
+        </div>
+        </li>
+    <li class="col-xl-6 col-md-6">
+        <div class="feature-card">
+            <div class="content"><a href="/contribute/writing-contests/">
+            <div class="content-container">
+              <div class="card-title"><h2 class="zg-text-bg bg-yellow">Bitcoin Writing Contest</h2><span class="zg-label ml-1 bg-yellow">03</span></div> 
+                <p class="card-desc">Contribute articles, tutorials and guides on Rootstock.</p>
+            </div>
+            </a><div class="btn-container"><a href="/contribute/writing-contests/">
+                </a><a class="green" href="https://www.contests.hackernoon.com/bitcoin-writing-contest">Enter the Contest</a>
+            </div>
+            </div>
+        </div>
+        </li>
+    </ul>
+</div>

--- a/content/rsk-devportal/contribute/index.md
+++ b/content/rsk-devportal/contribute/index.md
@@ -8,17 +8,15 @@ description: "An overview of different ways you can contribute to Rootstock."
 tags: rootstock, workshop, pre-requisites
 ---
 
-Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, bounty hunting, solving real-world problems, and eager to contribute to the future of Bitcoin and Decentralized Finance? Join the [Rootstock Discord Community](https://rootstock.io/discord) and start making contributions to the Rootstock Platform!
+Are you passionate about web3, bitcoin and the Blockchain? Do you have a passion for Open Source and Web3? Do you enjoy writing, coding, bounty hunting, solving real-world problems, and eager to contribute to the future of Bitcoin and Decentralized Finance? Join the [Rootstock Discord Community](https://rootstock.io/discord) and start making contributions!
 
 ## Who is it for?
 
 Whether you're a seasoned developer, creative writer, researcher, bug bounty hunter, or simply enthusiastic about blockchain, the program welcomes contributors from all backgrounds.
 
-## Rewards and Recognition
+## Getting Started
 
-From writing contests to bug bounties and open-source projects, there are various ways to participate and earn valuable incentives. Not only that, but you'll also get a chance to build your portfolio by writing and solving problems with real problems and use-cases in the Rootstock ecosystem.
-
-Explore the various ways you can contribute to Rootstock:
+From writing, bug bounties and open-source projects, there are various ways to participate and earn valuable incentives. 
 
 <div class="features-list">
     <ul id="card-list" class="row">

--- a/content/rsk-devportal/contribute/writing-contests.md
+++ b/content/rsk-devportal/contribute/writing-contests.md
@@ -1,0 +1,86 @@
+---
+layout: rsk
+title: Bitcoin Writing Contest
+menu_order: 220
+menu_title: Bitcoin Writing Contest
+section_title: Bitcoin Writing Contest
+description: "The #bitcoin Writing Contest, presented by Rootstock and HackerNoon, is now live with a total prize pool of $17,500 up for grabs! Whether you're a thought leader, a skilled writer, a talented developer, or simply passionate about blockchain technology, this contest invites you to showcase your expertise in various Bitcoin-related topics."
+tags: rootstock, workshop, pre-requisites, hackernoon, writing, tutorials, guides
+render_features: 'collapsible'
+---
+
+The #bitcoin Writing Contest, presented by Rootstock and HackerNoon, is now live with a total prize pool of $17,500 up for grabs! 
+
+Contest entries should showcase thought leadership, dev stack and tooling, and also creating engaging tutorials and guides in the realm of Bitcoin and Rootstock. Submit a story with the #bitcoin tag on HackerNoon. Submit a story with the `#bitcoin` tag on HackerNoon.
+
+> Looking to contribute code or contribute to the security of the Rootstock platform? 
+> - See the [Contribute](/contribute/) section for more exciting ways to contribute to Rootstock.
+
+<div class="btn-container">
+  <span></span>
+    <a class="green" href="https://www.contests.hackernoon.com/bitcoin-writing-contest">Register for the Contest on Hackernoon</a>
+</div>
+
+## Contest Themes
+
+The contest welcomes submissions under the following themes:
+
+* Thought Leadership: Writers will explore various Bitcoin topics, both new and old, such as Runes, ordinals, layer 2 solutions, sidechains, etc. This theme aims to associate Rootstock with all Bitcoin related topics surfacing Rootstock as a thought leader in the space. 
+* Dev Stack and Tooling: Articles will delve into the development stack and tooling related to building on Bitcoin, including SDKs, APIs, smart contract development frameworks, etc. This theme aims to attract developers and showcase the technical capabilities for building on Bitcoin.
+* Tutorials and Guides: Writers will provide step-by-step tutorials on how to build applications, smart contracts, or implement specific features on Rootstock. These tutorials will serve as practical guides for developers and enthusiasts looking to start building on Bitcoin.
+
+### Timeline and Rounds
+
+The contest consists of 3 rounds and will run for six months.
+
+* Round 1: May 22 - July 21, 2024
+* Round 2: July 22 - September 21, 2024
+* Round 3: September 22 - November 22, 2024
+
+> For more information, visit the [#bitcoin contest page on hackernoon](https://www.contests.hackernoon.com/bitcoin-writing-contest) for timelines and when to submit your application.
+
+### Prizes
+
+Here's a breakdown of the prizes for the best submissions.
+
+* 1st prize - $2,000
+* 2nd prize - $1,500
+* 3rd prize - $1,000
+
+> 2 Bonus Prizes worth $650 each for bitcoin thought-leadership submissions every round!
+
+### Rules and Guidelines
+Read the guidelines for the contest on [hackernoon](https://www.contests.hackernoon.com/bitcoin-writing-contest).
+
+## FAQs
+
+Here are some frequently asked questions about the contest. For more information on guidelines prizes, duration and FAQs, 
+see the [#bitcoin Writing Contest Rules & Guidelines](https://www.contests.hackernoon.com/bitcoin-writing-contest).
+
+[](#top "collapsible")
+- Who can participate in the Hackernoon Writing Contest?
+    - Anyone passionate about Bitcoin and Rootstock can participate. Whether you're a developer, enthusiast, or industry expert, we welcome your unique perspectives.
+- What types of content are eligible for submission?
+    - We accept articles showcasing thought leadership, development insights, and tutorials related to Bitcoin and Rootstock. This includes opinion pieces, technical guides, and how-to tutorials.
+- What are the contest themes?
+    - The contest focuses on three main themes: Thought Leadership, Dev Stack & Tooling, and Tutorials. Each theme encourages contributors to explore specific aspects of Bitcoin and Rootstock.
+- How long is the contest duration?
+    - The contest runs for 6 months, providing ample time for participants to create and submit their entries.
+- What are the prizes for the winners?
+    - Details about contest prizes will be announced closer to the submission deadline. Stay tuned for exciting rewards!
+- How do I register for the contest?
+    - To register, visit the [Contest Page on Hackernoon](https://www.contests.hackernoon.com/bitcoin-writing-contest) and follow the instructions to sign up as a participant.
+- Are there any specific guidelines for submissions?
+    - Yes, detailed contest rules and guidelines are provided on the [Hackernoon platform](https://www.contests.hackernoon.com/bitcoin-writing-contest). Make sure to review them before submitting your entry.
+- Where can I find more information about Rootstock?
+    - Explore additional resources such as the Rootstock website, Developer Portal, Blog, and Discord Community for insights and inspiration. See [Useful Guides and Resources](#useful-guides-and-resources)
+- How will winners be notified?
+    - Winners will be notified via email or through official announcements on Hackernoon and Rootstock platforms.
+- Can I republish my contest entry elsewhere after submission?
+    - Participants retain the rights to their submissions but should review [Hackernoon's guidelines](https://www.contests.hackernoon.com/bitcoin-writing-contest) regarding republishing after the contest.
+
+## Useful Guides and Resources
+* [Rootstock Website](https://rootstock.io/)
+* [Rootstock Blog](https://blog.rootstock.io/)
+* [Starter Kits](/guides/starter-kits/)
+* [Rootstock Discord Community](https://rootstock.io/discord)

--- a/content/rsk-devportal/contribute/writing-contests.md
+++ b/content/rsk-devportal/contribute/writing-contests.md
@@ -11,14 +11,14 @@ render_features: 'collapsible'
 
 The #bitcoin Writing Contest, presented by Rootstock and HackerNoon, is now live with a total prize pool of $17,500 up for grabs! 
 
-Contest entries should showcase thought leadership, dev stack and tooling, and also creating engaging tutorials and guides in the realm of Bitcoin and Rootstock. Submit a story with the #bitcoin tag on HackerNoon. Submit a story with the `#bitcoin` tag on HackerNoon.
+Contest entries should showcase thought leadership, dev stack and tooling, and also creating engaging tutorials and guides in the realm of Bitcoin and Rootstock. Submit a story with the #bitcoin tag on HackerNoon. Submit a story with the `#bitcoin` tag on HackerNoon, read the [3 Steps to Enter The #bitcoin Writing Contest](https://www.contests.hackernoon.com/how-to-enter-bitcoin-writing-contest).
 
 > Looking to contribute code or contribute to the security of the Rootstock platform? 
 > - See the [Contribute](/contribute/) section for more exciting ways to contribute to Rootstock.
 
 <div class="btn-container">
   <span></span>
-    <a class="green" href="https://www.contests.hackernoon.com/bitcoin-writing-contest">Register for the Contest on Hackernoon</a>
+    <a class="green" href="https://www.contests.hackernoon.com/bitcoin-writing-contest">Register for the Contest on HackerNoon</a>
 </div>
 
 ## Contest Themes
@@ -50,7 +50,8 @@ Here's a breakdown of the prizes for the best submissions.
 > 2 Bonus Prizes worth $650 each for bitcoin thought-leadership submissions every round!
 
 ### Rules and Guidelines
-Read the guidelines for the contest on [hackernoon](https://www.contests.hackernoon.com/bitcoin-writing-contest).
+
+Read the guidelines for the contest on [HackerNoon](https://www.contests.hackernoon.com/bitcoin-writing-contest).
 
 ## FAQs
 
@@ -58,7 +59,7 @@ Here are some frequently asked questions about the contest. For more information
 see the [#bitcoin Writing Contest Rules & Guidelines](https://www.contests.hackernoon.com/bitcoin-writing-contest).
 
 [](#top "collapsible")
-- Who can participate in the Hackernoon Writing Contest?
+- Who can participate in the HackerNoon Writing Contest?
     - Anyone passionate about Bitcoin and Rootstock can participate. Whether you're a developer, enthusiast, or industry expert, we welcome your unique perspectives.
 - What types of content are eligible for submission?
     - We accept articles showcasing thought leadership, development insights, and tutorials related to Bitcoin and Rootstock. This includes opinion pieces, technical guides, and how-to tutorials.
@@ -69,15 +70,15 @@ see the [#bitcoin Writing Contest Rules & Guidelines](https://www.contests.hacke
 - What are the prizes for the winners?
     - Details about contest prizes will be announced closer to the submission deadline. Stay tuned for exciting rewards!
 - How do I register for the contest?
-    - To register, visit the [Contest Page on Hackernoon](https://www.contests.hackernoon.com/bitcoin-writing-contest) and follow the instructions to sign up as a participant.
+    - To register, visit the [Contest Page on HackerNoon](https://www.contests.hackernoon.com/bitcoin-writing-contest) and follow the instructions to sign up as a participant.
 - Are there any specific guidelines for submissions?
-    - Yes, detailed contest rules and guidelines are provided on the [Hackernoon platform](https://www.contests.hackernoon.com/bitcoin-writing-contest). Make sure to review them before submitting your entry.
+    - Yes, detailed contest rules and guidelines are provided on the [HackerNoon platform](https://www.contests.hackernoon.com/bitcoin-writing-contest). Make sure to review them before submitting your entry.
 - Where can I find more information about Rootstock?
     - Explore additional resources such as the Rootstock website, Developer Portal, Blog, and Discord Community for insights and inspiration. See [Useful Guides and Resources](#useful-guides-and-resources)
 - How will winners be notified?
-    - Winners will be notified via email or through official announcements on Hackernoon and Rootstock platforms.
+    - Winners will be notified via email or through official announcements on HackerNoon and Rootstock platforms.
 - Can I republish my contest entry elsewhere after submission?
-    - Participants retain the rights to their submissions but should review [Hackernoon's guidelines](https://www.contests.hackernoon.com/bitcoin-writing-contest) regarding republishing after the contest.
+    - Participants retain the rights to their submissions but should review [HackerNoon's guidelines](https://www.contests.hackernoon.com/bitcoin-writing-contest) regarding republishing after the contest.
 
 ## Useful Guides and Resources
 * [Rootstock Website](https://rootstock.io/)

--- a/content/rsk-devportal/contribute/writing-contests.md
+++ b/content/rsk-devportal/contribute/writing-contests.md
@@ -25,9 +25,9 @@ Contest entries should showcase thought leadership, dev stack and tooling, and a
 
 The contest welcomes submissions under the following themes:
 
-* Thought Leadership: Writers will explore various Bitcoin topics, both new and old, such as Runes, ordinals, layer 2 solutions, sidechains, etc. This theme aims to associate Rootstock with all Bitcoin related topics surfacing Rootstock as a thought leader in the space. 
-* Dev Stack and Tooling: Articles will delve into the development stack and tooling related to building on Bitcoin, including SDKs, APIs, smart contract development frameworks, etc. This theme aims to attract developers and showcase the technical capabilities for building on Bitcoin.
-* Tutorials and Guides: Writers will provide step-by-step tutorials on how to build applications, smart contracts, or implement specific features on Rootstock. These tutorials will serve as practical guides for developers and enthusiasts looking to start building on Bitcoin.
+* Thought Leadership: Explore various topics about Bitcoin, both new and old, such as Runes, what Satoshi’s writings mean to you, ordinals, layer 2 solutions, sidechains, how Bitcoin changed finance forever, and/or quality analysis about its price prediction or impact on inflation. 
+* Dev Stack and Tooling: Delve into the development stack and tooling related to building on Bitcoin, including SDKs, APIs, smart contract development frameworks, etc. Developers and makers should showcase the technical capabilities for building with Bitcoin.
+* Tutorials and Guides: Provide step-by-step tutorials and guides on how to build applications, smart contracts, or implement specific features. Bonus points for building with Rootstock. These tutorials and guides will serve as practical guides for developers and enthusiasts looking to start building on Bitcoin.
 
 ### Timeline and Rounds
 

--- a/src/components/before-content/component-one/index.tsx
+++ b/src/components/before-content/component-one/index.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 const ComponentOne = () => {
     return(
-        <a href="https://rootstock.io/referral/" target="_blank" rel="noopener noreferrer">Rootstock Grants Referral program is live! Refer a builder on Bitcoin and earn $250!
+        <a href="/contribute/writing-contests/" target="_blank" rel="noopener noreferrer">The #bitcoin Writing Contest on Hackernoon is now live with a total prize pool of up to $17,500 up for grabs! 
+        Submit a story with the #bitcoin tag on HackerNoon
         </a>
     )
 }

--- a/src/components/before-content/component-one/index.tsx
+++ b/src/components/before-content/component-one/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 const ComponentOne = () => {
     return(
-        <a href="/contribute/writing-contests/" target="_blank" rel="noopener noreferrer">The #bitcoin Writing Contest on Hackernoon is now live with a total prize pool of up to $17,500 up for grabs! 
-        Submit a story with the #bitcoin tag on HackerNoon
+        <a href="/contribute/writing-contests/" target="_blank" rel="noopener noreferrer">The #bitcoin Writing Contest on HackerNoon is now live with a total prize pool of up to $17,500! 
+        Submit a story with the #bitcoin tag on HackerNoon.
         </a>
     )
 }

--- a/src/components/before-content/component-three/index.tsx
+++ b/src/components/before-content/component-three/index.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 const ComponentThree = () => {
     return(
-        <a href="https://taikai.network/en/rootstock/hackathons/bitcoin-rootstock-hackathon/overview" target="_blank" rel="noopener noreferrer"> Participate in the Bitcoin Meets Solidity Hackathon and win up to 17k USD in prizes by 10th June, 2024. 
+        <a href="https://github.com/rsksmart/rskj/releases/tag/ARROWHEAD-6.2.0" target="_blank" rel="noopener noreferrer"> Optional Upgrade: RSKj Arrowhead 6.2.0 now live. 
+        This update mainly focuses on improving Ethereum compatibility at the JSON-RPC interface and peer discovery enhancements. 
       </a>
     )
 }

--- a/src/components/before-content/component-three/index.tsx
+++ b/src/components/before-content/component-three/index.tsx
@@ -3,7 +3,6 @@ import React from "react";
 const ComponentThree = () => {
     return(
         <a href="https://taikai.network/en/rootstock/hackathons/bitcoin-rootstock-hackathon/overview" target="_blank" rel="noopener noreferrer"> Participate in the Bitcoin Meets Solidity Hackathon and win up to 17k USD in prizes by 10th June, 2024. 
-        Start Hacking.
       </a>
     )
 }

--- a/src/components/before-content/component-two/index.tsx
+++ b/src/components/before-content/component-two/index.tsx
@@ -2,8 +2,7 @@ import React from "react";
 
 const ComponentTwo = () => {
     return(
-        <a href="https://blog.rootstock.io/noticia/arrowhead-6-1-0-release-what-you-need-to-know/" target="_blank" rel="noopener noreferrer"> 
-      Latest version of RSKj now available on GitHub! While this upgrade is optional, it is recommended that users update their nodes to the recent version (Arrowhead v6.1.0) for an enhanced experience.
+        <a href="https://blog.rootstock.io/noticia/rootstock-roadmap-2024-2025/" target="_blank" rel="noopener noreferrer"> Introducing the Rootstock Roadmap for 2024/25, from BitVMX-based trustless bridges to Lightning and Boltz integrations boosting accessibility, deep dive into the roadmap now!.
       </a>
     )
 }

--- a/src/components/before-content/component-two/index.tsx
+++ b/src/components/before-content/component-two/index.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 const ComponentTwo = () => {
     return(
-        <a href="https://blog.rootstock.io/noticia/rootstock-roadmap-2024-2025/" target="_blank" rel="noopener noreferrer"> Introducing the Rootstock Roadmap for 2024/25, from BitVMX-based trustless bridges to Lightning and Boltz integrations boosting accessibility, deep dive into the roadmap now!.
+        <a href="https://blog.rootstock.io/noticia/rootstock-ambassador-program/" target="_blank" rel="noopener noreferrer"> Applications to the Rootstock Ambassador Program is now open! 
+        Click to read more about the program and earn rewards while contributing to the Rootstock Platform.
       </a>
     )
 }

--- a/src/components/before-content/index.tsx
+++ b/src/components/before-content/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import classnames from "classnames";
 import Marquee from "react-fast-marquee";
+import ComponentOne from "./component-one";
+import ComponentTwo from "./component-two";
 import ComponentThree from "./component-three";
 
 interface Props {
@@ -11,6 +13,10 @@ const BeforeContent = ({ className }: Props) => {
   return ( 
       <div className={classnames('before-content', className)}> 
       <Marquee style={{'minHeight': '30px'}}>    
+       <ComponentOne />
+        &nbsp;
+        <ComponentTwo />
+        &nbsp;
         <ComponentThree />
         &nbsp;
       </Marquee>

--- a/src/components/before-content/index.tsx
+++ b/src/components/before-content/index.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames";
 import Marquee from "react-fast-marquee";
 import ComponentOne from "./component-one";
 import ComponentTwo from "./component-two";
-import ComponentThree from "./component-three";
+// import ComponentThree from "./component-three";
 
 interface Props {
   className?: string;
@@ -17,8 +17,8 @@ const BeforeContent = ({ className }: Props) => {
         &nbsp;
         <ComponentTwo />
         &nbsp;
-        <ComponentThree />
-        &nbsp;
+        {/* <ComponentThree />
+        &nbsp; */}
       </Marquee>
       </div> 
   );


### PR DESCRIPTION
## What

- Added #bitcoin writing contest landing page
- Update before-content announcements

## Why

- Documentation updates and maintenance

## Refs

- [Task](https://rsklabs.atlassian.net/browse/DTW-123?atlOrigin=eyJpIjoiMzVhM2M5OGQ5ZDA0NDc4OThjYWM5Mjc1YWZhYWNiZmEiLCJwIjoiaiJ9)
