### PR TITLE
Docs: add in rns integrate addr rpc api reference

### DIFF
--- a/content/rsk-devportal/rif/rns/integrate/integrate-addr-resolution.md
+++ b/content/rsk-devportal/rif/rns/integrate/integrate-addr-resolution.md
@@ -85,7 +85,7 @@ This is a demonstration of how to get the address of a domain. We are going to d
     };
     ```
 
-    See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an api key, see [How to get started with RPC API](/tools/rpc-api/).
 
 4. Start the app
 

--- a/content/rsk-devportal/rif/rns/integrate/integrate-addr-resolution.md
+++ b/content/rsk-devportal/rif/rns/integrate/integrate-addr-resolution.md
@@ -61,7 +61,7 @@ This is a demonstration of how to get the address of a domain. We are going to d
 
         this.setState({ getting: true, addr: null, error: null  });
 
-        const web3 = new Web3('https://public-node.rsk.co')
+        const web3 = new Web3('https://rpc.rootstock.io/API_KEY') // or 'https://rpc.testnet.rootstock.io'
         const rns = new RNS(web3);
 
         rns.addr(domain)
@@ -84,6 +84,8 @@ This is a demonstration of how to get the address of a domain. We are going to d
     }
     };
     ```
+
+    See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
 
 4. Start the app
 

--- a/content/rsk-devportal/rif/rns/integrate/integrate-addr-resolution.md
+++ b/content/rsk-devportal/rif/rns/integrate/integrate-addr-resolution.md
@@ -61,7 +61,7 @@ This is a demonstration of how to get the address of a domain. We are going to d
 
         this.setState({ getting: true, addr: null, error: null  });
 
-        const web3 = new Web3('https://rpc.rootstock.io/API_KEY') // or 'https://rpc.testnet.rootstock.io'
+        const web3 = new Web3('https://rpc.mainnet.rootstock.io/API_KEY') // or 'https://rpc.testnet.rootstock.io'
         const rns = new RNS(web3);
 
         rns.addr(domain)


### PR DESCRIPTION
## What
Replace reference to the public nodes for a reference to the rpc API and add a reference to the Getting start.
 
 **Before**
 
<img width="844" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/d9fbd851-a510-4618-81c9-18351b014ff5">

 **After**
<img width="843" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/f5eef814-49db-4daf-9c87-ec8e52295909">

## Why
Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45

