### PR TITLE
docs: add in rif rollup reference to RPC API

### DIFF
--- a/content/rsk-devportal/rif/rollup/dev-reference/sdk.md
+++ b/content/rsk-devportal/rif/rollup/dev-reference/sdk.md
@@ -32,10 +32,14 @@ This section contains documentation for the JS SDK for RIF Rollup. In this secti
 
 Here is a list of items necessary for setting up and running the Javascript SDK.
 
-* Ethersjs Library (v5.0). See how to setup Ethersjs on the [official site](https://docs.ethers.org/v5/getting-started/)
-* Node (v18.0 and above). See [how to install nodejs using NVM](https://nodejs.org/en/download/package-manager#nvm)
+* Ethersjs Library (v5.0).
+  * See how to setup Ethersjs on the [official site](https://docs.ethers.org/v5/getting-started/).
+* Node (v18.0 and above).
+  * See [how to install nodejs using NVM](https://nodejs.org/en/download/package-manager#nvm).
 * RBTC.
     * See how to get test tokens using the [Rootstock Faucet](https://faucet.rsk.co/) or see the guide on how to [Get Crypto on Rootstock](/guides/get-crypto-on-rsk/).
+* Get an API key to interact with the RPC API.
+    * See the guide on [how to get started with RPC API](/tools/rpc-api/).
 
 ## Dependencies
 * zkSync
@@ -95,7 +99,7 @@ const ethersProvider = ethers.getDefaultProvider(network);
 > Note that the command may not always work (as Ethers do not always support Rootstock connections), use the workaround as shown below;
 
 ```js
-const RSK_TESTNET_NODE_URL = "https://public-node.testnet.rsk.co";
+const RSK_TESTNET_NODE_URL = "https://rpc.testnet.rootstock.io/";
 const ethersProvider = new ethers.providers.JsonRpcProvider(RSK_TESTNET_NODE_URL);
 ```
 


### PR DESCRIPTION
## What

Replace reference to the public nodes for a reference to the rpc API and add a reference to the get started guide.

Before
<img width="788" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/76450956-d120-4d9a-a22f-471e84e1d221">
<img width="825" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/efbaf268-7669-4868-b009-96d8538d8451">


After
<img width="793" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/b49886a5-4f03-4800-a866-8d3f66f50090">
<img width="889" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/7508ad2c-4714-450a-bf44-1fed79c6a822">

## Why

Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45
