### PR TITLE
docs: add in kb/rskj reference to RPC API

### DIFF
--- a/content/rsk-devportal/kb/rskj.md
+++ b/content/rsk-devportal/kb/rskj.md
@@ -13,8 +13,7 @@ You can run
 [RSKj](/rsk/node/) locally to connect to the public Rootstock networks -
 [RSK Mainnet](https://explorer.rsk.co/), and the
 [RSK Testnet](https://explorer.testnet.rsk.co/).
-This is an alternative to connecting to the
-[public nodes](/rsk/public-nodes/).
+This is an alternative to using the [RPC API](/tools/rpc-api/).
 
 RSKj can also run in a “localhost”-only environment, without connecting to any public network - [Rootstock Regtest](/rsk/node/configure/switch-network/#regtest)
 

--- a/content/rsk-devportal/kb/rskj.md
+++ b/content/rsk-devportal/kb/rskj.md
@@ -11,9 +11,9 @@ layout: 'rsk'
 
 You can run
 [RSKj](/rsk/node/) locally to connect to the public Rootstock networks -
-[RSK Mainnet](https://explorer.rsk.co/), and the
-[RSK Testnet](https://explorer.testnet.rsk.co/).
-This is an alternative to using the [RPC API](/tools/rpc-api/).
+[Rootstock Mainnet](https://explorer.rsk.co/), and the
+[Rootstock Testnet](https://explorer.testnet.rsk.co/).
+Or use the [RPC API](/tools/rpc-api/).
 
 RSKj can also run in a “localhost”-only environment, without connecting to any public network - [Rootstock Regtest](/rsk/node/configure/switch-network/#regtest)
 


### PR DESCRIPTION
## What

Replace reference to the public nodes for a reference to the RPC API and add a reference to the get started guide.

Before
<img width="840" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/adae2ac4-a5d5-4637-8c74-34004d34a549">

After
<img width="861" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/bc530696-b16e-4ca9-b9fd-48d233cd5e5a">


## Why

Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45
