### PR TITLE
docs: add in hardhat guide reference to RPC API

### DIFF
--- a/content/rsk-devportal/guides/quickstart/hardhat/configure-hardhat.md
+++ b/content/rsk-devportal/guides/quickstart/hardhat/configure-hardhat.md
@@ -36,6 +36,8 @@ To manage environment variables, install `dotenv` using the following command:
 
 > Note: Depending on your desired network, using a Testnet and Mainnet private key is optional, as you're not required to have separate private keys in your environment variable.
 
+> Replace `"your_mainnet_private_key"` and `"your_testnet_private_key"` with your private keys. For information on how to retrieve your private keys, see [How to export an account's private key](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
+
 ### Step 2: Configure Private Keys
 
 To configure your `rskMainnet` and `rskTestnet` private keys, you'll need to update your `hardhat.config.js` file in the root directory with your private keys.
@@ -51,13 +53,13 @@ To configure your `rskMainnet` and `rskTestnet` private keys, you'll need to upd
     solidity: "0.8.20",
     networks: {
       rskMainnet: {
-        url: "https://public-node.rsk.co",
+        url: "https://rpc.rootstock.io/API_KEY",
         chainId: 30,
         gasPrice: 60000000,
         accounts: [process.env.ROOTSTOCK_MAINNET_PRIVATE_KEY]
       },
       rskTestnet: {
-        url: "https://public-node.testnet.rsk.co",
+        url: "https://rpc.testnet.rootstock.io/API_KEY",
         chainId: 31,
         gasPrice: 60000000,
         accounts: [process.env.ROOTSTOCK_TESTNET_PRIVATE_KEY]
@@ -66,7 +68,7 @@ To configure your `rskMainnet` and `rskTestnet` private keys, you'll need to upd
   };
 ```
 
-> Replace `"your_mainnet_private_key"` and `"your_testnet_private_key"` with your private keys. For information on how to retrieve your private keys, see [How to export an account's private key](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an api key, see [How to get started with RPC API](/tools/rpc-api/).
 
 ### Step 3: Fund Your Accounts
 [](#top "collapsible")

--- a/content/rsk-devportal/guides/quickstart/hardhat/configure-hardhat.md
+++ b/content/rsk-devportal/guides/quickstart/hardhat/configure-hardhat.md
@@ -53,7 +53,7 @@ To configure your `rskMainnet` and `rskTestnet` private keys, you'll need to upd
     solidity: "0.8.20",
     networks: {
       rskMainnet: {
-        url: "https://rpc.rootstock.io/API_KEY",
+        url: "https://rpc.mainnet.rootstock.io/API_KEY",
         chainId: 30,
         gasPrice: 60000000,
         accounts: [process.env.ROOTSTOCK_MAINNET_PRIVATE_KEY]


### PR DESCRIPTION
## What

Replace reference to the public nodes for a reference to the RPC API and add a reference to the get started guide.

**Before**
<img width="822" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/39a5f8e9-60d5-4aaf-8861-d23ebc3be2f1">
<img width="814" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/d2fad05d-0ca6-48a9-84e7-a06ec3c51714">


**After**
<img width="844" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/9b7d1e3a-6cf4-40d2-af0a-c2f94990e3f7">
<img width="839" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/03c6d853-bb32-4a9d-a782-3141a3c44d36">

## Why

Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45
