### PR TITLE
docs: add in foundry guide reference to RPC API

### DIFF
--- a/content/rsk-devportal/tools/foundry.md
+++ b/content/rsk-devportal/tools/foundry.md
@@ -110,20 +110,22 @@ forge test
 
 ### Deploy contract on the Rootstock
 
-To deploy the counter contract on Rootstock mainnet or testnet, further configure Foundry by setting up a Rootstock RPC url and a private key of an account that’s funded with tRBTC. 
+To deploy the counter contract on Rootstock mainnet or testnet, further configure Foundry by setting up a [Rootstock RPC URL](/tools/rpc-api/) and a private key of an account that’s funded with tRBTC. 
 
 #### Environment Configuration
 
-Once you have an account with a private key, create a `.env` file in the root of the foundry project and add the variables. 
+Once you have an account with a private key and a API key to interact with the RPC API, create a `.env` file in the root of the foundry project and add the variables. 
 
 Foundry automatically loads a `.env` file present in the project directory.
 
 The `.env` file should follow this format:
 
 ```bash
-ROOTSTOCK_RPC_URL=https://public-node.testnet.rsk.co
+ROOTSTOCK_RPC_URL=https://rpc.testnet.rootstock.io/API_KEY
 PRIVATE_KEY=0x...
 ```
+
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an API key, see [How to get started with RPC API](/tools/rpc-api/).
 
 At the root of the project, run:
 

--- a/content/rsk-devportal/tools/foundry.md
+++ b/content/rsk-devportal/tools/foundry.md
@@ -114,7 +114,7 @@ To deploy the counter contract on Rootstock mainnet or testnet, further configur
 
 #### Environment Configuration
 
-Once you have an account with a private key and a API key to interact with the RPC API, create a `.env` file in the root of the foundry project and add the variables. 
+Once you have an account with a private key and an API key to interact with the RPC API, create a `.env` file in the root of the foundry project and add the variables. 
 
 Foundry automatically loads a `.env` file present in the project directory.
 


### PR DESCRIPTION
## What

Replace reference to the public nodes for a reference to the RPC API and add a reference to the get started guide.

**Before**
<img width="835" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/c807a428-e9eb-4583-881e-ff573ab0588a">

**After**
<img width="825" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/6756ec3c-bc2c-48a4-9156-2a4e9f534423">

## Why

Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45
