### PR TITLE
docs: add in rsk index reference to rpc api

### DIFF
--- a/content/rsk-devportal/rsk/index.md
+++ b/content/rsk-devportal/rsk/index.md
@@ -20,7 +20,7 @@ To learn more about Rootstock architecture, please refer to the [Original](https
 Rootstock has two networks, one is a development or testing network (also known as Testnet), and the other a production network (Mainnet), with blocks every 30 seconds.
 
 To interact with the network, you need access to a node. The following are the available options:
-- [Use public nodes](/rsk/public-nodes)
+- [RPC API](/tools/rpc-api/)
 - [Install node](/rsk/node/install)
 - [Compile the node code](/rsk/node/contribute/)
 - [Powpeg HSM Firmware Attestation](/rsk/architecture/powpeg#powpeg-hsm-firmware-attestation)


### PR DESCRIPTION
## What
Replace reference to the public nodes for a reference to the rpc API and add a reference to the Getting start.

**Before**
<img width="809" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/37d1e0d4-2576-49a5-8b75-dcedca35ca8f">

**After**
![image](https://github.com/rsksmart/devportal/assets/161861597/a2784c8d-25d8-4fc3-a252-4efede34db1e)

## Why

Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45
