### PR TITLE
docs: add in rns-tool-Web3  reference to RPC API

### DIFF
--- a/content/rsk-devportal/rif/rns/tools/Web3.md
+++ b/content/rsk-devportal/rif/rns/tools/Web3.md
@@ -6,7 +6,7 @@ title: How to Use Web3 to Interact with Smart Contracts | Rootstock (RSK)
 tags: rif, rns, rif-name-service, node, sdk, libraries, infrastructure, protocols, mvp, design, rbtc, defi, decentralized, quick-start, guides, tutorial, networks, dapps, tools, rootstock, rsk, ethereum, smart-contracts, install, get-started, how-to, mainnet, testnet, contracts, wallets, web3, crypto
 ---
 
-To use web3 and interact with the contracts, we must instance `web3` with a provider. To do so we can use [Rootstock (RSK) public nodes](https://nodes.rsk.co):
+To use web3 and interact with the contracts, we must instance `web3` with a provider. To do so we can use the [RPC API](/tools/rpc-api/):
 
 ```js
 var Web3 = require('web3')


### PR DESCRIPTION
## What

Replace reference to the public nodes for a reference to the rpc API and add a reference to the Getting start.

**Before**
<img width="831" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/d6de5442-ad20-43b7-9f1a-e006671d2bff">

**After**
![image](https://github.com/rsksmart/devportal/assets/161861597/fb1f6830-a7fb-42b3-b036-cec579568856)

## Why

Public nodes will no longer be use

## Refs

[https://rsklabs.atlassian.net/browse/DV-45](https://rsklabs.atlassian.net/browse/DV-45)
