### PR TITLE
docs: add in rns/libs/js reference to RPC API

### DIFF
--- a/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
@@ -54,7 +54,7 @@ async function myCustomGetOwner(domain) {
 }
 ```
 
-See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an api key, see [How to get started with RPC API](/tools/rpc-api/).
 
 ## Advanced usage
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
@@ -39,7 +39,7 @@ If the `networkId` is not provided, and the current blockchain is not Rootstock 
 **Example**
 ```javascript
 async function myCustomGetOwner(domain) {
-  const web3 = new Web3('https://public-node.rsk.co');
+  const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/';
 
   const options = {
     contractAddresses: {
@@ -54,6 +54,7 @@ async function myCustomGetOwner(domain) {
 }
 ```
 
+See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
 
 ## Advanced usage
 
@@ -63,7 +64,7 @@ The library must be composed before accessing to the contracts, if not, it will 
 
 ```javascript
 async function myCustomGetOwner(domain) {
-  const web3 = new Web3('https://public-node.rsk.co')
+  const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/'
   const rns = new RNS(web3)
   await rns.compose()
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
@@ -73,4 +73,6 @@ async function myCustomGetOwner(domain) {
 }
 ```
 
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an api key, see [How to get started with RPC API](/tools/rpc-api/).
+
 ## Want to contribute? Find the process [here](/rif/rns/libs/javascript/Contribute/)

--- a/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/Advanced-usage.md
@@ -39,7 +39,7 @@ If the `networkId` is not provided, and the current blockchain is not Rootstock 
 **Example**
 ```javascript
 async function myCustomGetOwner(domain) {
-  const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/';
+  const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.mainnet.rootstock.io/API_KEY';
 
   const options = {
     contractAddresses: {
@@ -64,7 +64,7 @@ The library must be composed before accessing to the contracts, if not, it will 
 
 ```javascript
 async function myCustomGetOwner(domain) {
-  const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/'
+  const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.mainnet.rootstock.io/API_KEY'
   const rns = new RNS(web3)
   await rns.compose()
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/RNS-instance.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/RNS-instance.md
@@ -34,7 +34,7 @@ const rns = new RNS(web3)
 
 > Remember that if you are running the code in a webpage, no `import` statements are needed, just instantiate the libs made available in the global scope.
 
-See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an api key, see [How to get started with RPC API](/tools/rpc-api/).
 
 ## Instance in Chrome with wallet extension (Metamask)
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/RNS-instance.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/RNS-instance.md
@@ -28,11 +28,13 @@ Or just use it directly in your webpage:
 import Web3 from 'web3'
 import RNS from '@rsksmart/rns'
 
-const web3 = new Web3('https://public-node.rsk.co') // or 'https://public-node.testnet.rsk.co'
+const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/'
 const rns = new RNS(web3)
 ```
 
 > Remember that if you are running the code in a webpage, no `import` statements are needed, just instantiate the libs made available in the global scope.
+
+See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
 
 ## Instance in Chrome with wallet extension (Metamask)
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/RNS-instance.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/RNS-instance.md
@@ -28,7 +28,7 @@ Or just use it directly in your webpage:
 import Web3 from 'web3'
 import RNS from '@rsksmart/rns'
 
-const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/'
+const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.mainnet.rootstock.io/API_KEY'
 const rns = new RNS(web3)
 ```
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/index.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/index.md
@@ -38,7 +38,7 @@ rns.addr('testing.rsk').then(console.log)
 
 Are you excited about it and want to know more? Let's dive into the library with our [getting started](/rif/rns/libs/javascript/Getting-started) guide for beginners, or jump directly to the [available operations](/rif/rns/libs/javascript/Operations) section and start using them in your local environment. You can even try them out right here on this page:
 
-<script async src="//jsfiddle.net/javiesses/y2up4908/embed/js,html,result/dark/"></script>
+<script async src="//jsfiddle.net/anonymoussssrs/bduearnw/1/embed/js,html,css,result/dark/"></script>
 <br />
 
 **RNS JS** has been built by and for developers, so we are always looking for collaboration. Check out our [contribution](/rif/rns/libs/javascript/Contribute) section, where you will find how can help RNS with proposals, issues, or pull requests.

--- a/content/rsk-devportal/rif/rns/libs/javascript/index.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/index.md
@@ -28,7 +28,7 @@ const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https:/
 const rns = new RNS(web3)
 ```
 
-See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
+> Replace `"API_KEY"` with the api key that you have created for this App. For information on how to create an api key, see [How to get started with RPC API](/tools/rpc-api/).
 
 ## 3. Get an address!
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/index.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/index.md
@@ -24,7 +24,7 @@ npm i web3 @rsksmart/rns
 import Web3 from 'web3'
 import RNS from '@rsksmart/rns'
 
-const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/'
+const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.mainnet.rootstock.io/API_KEY'
 const rns = new RNS(web3)
 ```
 

--- a/content/rsk-devportal/rif/rns/libs/javascript/index.md
+++ b/content/rsk-devportal/rif/rns/libs/javascript/index.md
@@ -24,9 +24,11 @@ npm i web3 @rsksmart/rns
 import Web3 from 'web3'
 import RNS from '@rsksmart/rns'
 
-const web3 = new Web3('https://public-node.rsk.co')
+const web3 = new Web3('https://rpc.testnet.rootstock.io/API_KEY') // or 'https://rpc.rootstock.io/'
 const rns = new RNS(web3)
 ```
+
+See [how to get started with RPC API](/tools/rpc-api/) and make your first API call in minutes.
 
 ## 3. Get an address!
 


### PR DESCRIPTION
## What

Replace reference to the public nodes for a reference to the RPC API and add a reference to the Getting start.

_**Advanced usage**_
**Before**
<img width="637" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/9a48dadd-35bc-4dd2-b557-47d038fd446a">

**After**
<img width="627" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/740e0228-7b79-4cf6-b008-aea096579b1e">

**_Instance for queries to RSK Mainnet/Testnet_**
**Before**
<img width="837" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/fb26a791-c8b6-4865-b8da-81a8e627021c">

**After**
<img width="630" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/1d191fde-8e17-4523-be11-07f0c69e16fb">

**_RNS JS Library_**
**Before**
<img width="857" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/f770a51b-adbc-4124-95f7-e1ef47a4c3ed">

**After**
<img width="622" alt="image" src="https://github.com/rsksmart/devportal/assets/161861597/ecfb04e7-b329-4cc0-be63-260bd8707154">
The code from jsfiddle is not loaded while the project is running in local, but the new source is this: https://jsfiddle.net/anonymoussssrs/bduearnw/1/

## Why

Public nodes will no longer be use

## Refs

https://rsklabs.atlassian.net/browse/DV-45
