### PR TITLE
Update docker.md

### DIFF
--- a/content/rsk-devportal/rsk/node/install/operating-systems/docker.md
+++ b/content/rsk-devportal/rsk/node/install/operating-systems/docker.md
@@ -35,3 +35,10 @@ More information about Docker install [here](https://docs.docker.com/install/).
 ## Install RSKj Using Docker
 
 To install a Rootstock node using Docker, visit the [Docker Hub](https://hub.docker.com/r/rsksmart/rskj) for installation instructions.
+
+## Logging in a RSKj Docker Container
+
+By default, a RSKj Docker container prints logs to STDOUT, making it easy to view the logs while the container is running. In order to not have them printed to STDOUT you can run the Docker container with the environment variable left empty. That command should follow this estructure:
+```
+docker run -e LOGGING_STDOUT= <container-name>
+```

--- a/content/rsk-devportal/rsk/node/install/operating-systems/docker.md
+++ b/content/rsk-devportal/rsk/node/install/operating-systems/docker.md
@@ -36,9 +36,14 @@ More information about Docker install [here](https://docs.docker.com/install/).
 
 To install a Rootstock node using Docker, visit the [Docker Hub](https://hub.docker.com/r/rsksmart/rskj) for installation instructions.
 
-## Logging in a RSKj Docker Container
+## Logging in RSKj
 
-By default, a RSKj Docker container prints logs to STDOUT, making it easy to view the logs while the container is running. In order to not have them printed to STDOUT you can run the Docker container with the environment variable left empty. That command should follow this estructure:
+By default, logs are exclusively directed to a single file. However, if you wish to enable the logging output to STDOUT, you can specify this system property via the command line using `-Dlogging.stdout=<LOG_LEVEL>`. That command should look something like this:
 ```
-docker run -e LOGGING_STDOUT= <container-name>
+java -Dlogging.stdout=INFO -cp <classpath> co.rsk.Start --reset --<RSK network>
+```
+
+Regarding the RSKj Docker containers, logs are printed to STDOUT by default, making it easy to view the logs while the container is running. In order to modify this, you can run the Docker container with the environment variable set to a different LOG_LEVEL (For example, DEBUG log level). That command should follow this structure:
+```
+docker run -e RSKJ_LOG_PROPS=DEBUG <container-name>
 ```


### PR DESCRIPTION
## What

Updated the Dockerfile to have new a environment variable that allows to print logs to STDOUT by default.

## Why

Some Rootstock users complain that it’s a hassle to make Docker / Docker Compose to print logs so we should enable logging to stdout by default in Docker containers and document this change.

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
