### PR TITLE
Updating eth_getTransactionReceipt to add the effectiveGasPrice

### DIFF
--- a/content/rsk-devportal/rsk/node/architecture/json-rpc/json-rpc-methods.md
+++ b/content/rsk-devportal/rsk/node/architecture/json-rpc/json-rpc-methods.md
@@ -1333,6 +1333,7 @@ params: [
   - `contractAddress `: `DATA`, 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise `null`.
   - `logs`: `Array` - Array of log objects, which this transaction generated.
   - `logsBloom`: `DATA`, 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.
+  - `effectiveGasPrice`: `QUANTITY` - The actual value per gas deducted on the transaction.
 
 It also returns _either_ :
 
@@ -1361,7 +1362,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","para
          // logs as returned by getFilterLogs, etc.
      }, ...],
      logsBloom: "0x00...0", // 256 byte bloom filter
-     status: '0x1'
+     status: '0x1',
+     effectiveGasPrice: '0x64' // 100
   }
 }
 ```


### PR DESCRIPTION
## What

- Updating the addition of the field effectiveGasPrice on the eth||_getTransactionReceipt RPC method, that it's the same value of the gasPrice on the transaction.

## Why

-  We are updating the RSKj node adding this field and want to let the documentation updated and synchronised with this change.

## Refs

- Please, don't merge until we effectively release this feature with the RSKj, we will keep you posted. This is the [PR](https://github.com/rsksmart/rskj/pull/2556) associated, when we release the rskj v6.4.0, we will update this PR and convert it from a Draft to an effective one.
