### PR TITLE
change getBalance script example input param from blockTag to blockNumber

### DIFF
--- a/content/rsk-devportal/tools/rpc-api.md
+++ b/content/rsk-devportal/tools/rpc-api.md
@@ -307,21 +307,21 @@ Find below a list of JSON-RPC methods available on the RPC API.
             - **Pending:** A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet. 
             - if not specified, it will return the balance at the latest block available.
     - Example request by `blockNumber`:
-        ```shell
-        curl --location 'https://rpc.testnet.rootstock.io/<api-key>' \
-        --request POST \
-        --header 'accept: application/json' \
-        --header 'Content-Type: application/json' \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getBalance",
-            "params":[
-        "0x1fab9a0e24ffc209b01faa5a61ad4366982d0b7f", 
-        "0x6444bb"
-		],
-            "id":0
-        }'
-        ```
+    ```shell
+    curl --location 'https://rpc.testnet.rootstock.io/<api-key>' \
+    --request POST \
+    --header 'accept: application/json' \
+    --header 'Content-Type: application/json' \
+    --data '{
+        "jsonrpc":"2.0",
+        "method":"eth_getBalance",
+        "params":[
+    "0x1fab9a0e24ffc209b01faa5a61ad4366982d0b7f", 
+    "0x6444bb"
+	],
+        "id":0
+    }'
+    ```
     - Example Response:
     ```shell
     {

--- a/content/rsk-devportal/tools/rpc-api.md
+++ b/content/rsk-devportal/tools/rpc-api.md
@@ -317,7 +317,8 @@ Find below a list of JSON-RPC methods available on the RPC API.
             "method":"eth_getBalance",
             "params":[
         "0x1fab9a0e24ffc209b01faa5a61ad4366982d0b7f", 
-        "latest"],
+        "0x6444bb"
+		],
             "id":0
         }'
         ```


### PR DESCRIPTION
## What

- In the first of three example scripts for the getBalance API query, change the input param from a blockTag to a blockNumber

## Why

- Script example 1 claims to use a blockNumber for the second param, while example 2 claims to use a blockHash and example 3 claims to use a blockTag. Script examples 2 and 3 correctly use the params they claim to, but example 1 erroneously had a blockTag instead of a blockHash

## Refs

- n/a
